### PR TITLE
Fixed arity for check_signature error path

### DIFF
--- a/lib/joken/claims.ex
+++ b/lib/joken/claims.ex
@@ -25,11 +25,11 @@ defmodule Joken.Claims do
 
   end
 
-  def check_signature({_status, _data}, _key) do
+  def check_signature({_status, _data}, _supported_algs, _key) do
     {:error, "Invalid JSON Web Token"}
   end
 
-  def check_signature(error, _key) do
+  def check_signature(error, _supported_algs, _key) do
     error
   end
 

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -137,4 +137,9 @@ defmodule JokenTest do
     assert(mesg == "Missing issuer")  
   end
 
+  test "malformed token" do
+    {status, _} = Joken.decode("foobar", @secret, %{ sub: "test", iss: "self", aud: "self:me" })
+    assert(status == :error)
+  end
+  
 end


### PR DESCRIPTION
Hi, thanks for the useful library! I noticed a small problem with badly formed tokens. I've added a fix and a test for it.