### PR TITLE
Claim sorting and signing

### DIFF
--- a/lib/joken/claims.ex
+++ b/lib/joken/claims.ex
@@ -2,15 +2,13 @@ defmodule Joken.Claims do
   alias Joken.Utils
   @moduledoc false
 
-  def check_signature({:ok, data},  _key, _json_module, _algorithm) when length(data) == 2 do
+  def check_signature({:ok, data},  _key, _json_module, _algorithm, _token) when length(data) == 2 do
     {:ok, Enum.fetch!(data, 1)}
   end
 
-  def check_signature({:ok, data}, key, json_module, algorithm) when length(data) == 3 do
+  def check_signature({:ok, data}, key, json_module, algorithm, token) when length(data) == 3 do
     [ header, payload, jwt_signature ] = data
-
-    header64 = header |> json_module.encode |> Utils.base64url_encode
-    payload64 = payload |> json_module.encode |> Utils.base64url_encode
+    [ header64, payload64, _ ] = String.split(token, ".")
 
     signature = :crypto.hmac(Utils.supported_algorithms[algorithm], key, "#{header64}.#{payload64}")
 
@@ -22,11 +20,11 @@ defmodule Joken.Claims do
 
   end
 
-  def check_signature({_status, _data}, _key, _json_module, _algorithm) do
+  def check_signature({_status, _data}, _key, _json_module, _algorithm, _token) do
     {:error, "Invalid JSON Web Token"}
   end
 
-  def check_signature(error, _key, _json_module, _algorithm) do
+  def check_signature(error, _key, _json_module, _algorithm, _token) do
     error
   end
 

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -51,7 +51,7 @@ defmodule Joken.Token do
   def decode(secret_key, json_module, token, algorithm \\ :HS256, claims \\ %{}) do
     token
     |> get_data(json_module)
-    |> Claims.check_signature(secret_key, json_module, algorithm)
+    |> Claims.check_signature(secret_key, json_module, algorithm, token)
     |> Claims.check_exp
     |> Claims.check_nbf
     |> Claims.check_aud(Map.get(claims, :aud, nil))

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -11,6 +11,15 @@ defmodule Joken.Token.Test do
   # generated at jwt.io with header {"typ": "JWT", "alg": "HS256"}, claim {"name": "John Doe"}, secret "test"
   @unsorted_header_token "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.B3tqUk6UdT8K5AQUGdYFXPj7R7_JznRi5PRrv_N7d1I"
 
+  @unsorted_payload %{
+    iss: "https://example.com/",
+    sub: "example|123456",
+    aud: "abc123",
+    iat: 1428371188
+  }
+  # generated at jwt.io with header {"typ": "JWT", "alg": "HS256"}, claim @unsorted_payload, secret "test"
+  @unsorted_payload_token "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tLyIsInN1YiI6ImV4YW1wbGV8MTIzNDU2IiwiYXVkIjoiYWJjMTIzIiwiaWF0IjoxNDI4MzcxMTg4fQ.w9Elb3Ogomd1hm0bAvjbrOPIDhZhgOxckG_ztDJVhJs"
+
   @poison_json_module Joken.TestPoison
   @jsx_json_module Joken.TestJsx
 
@@ -52,6 +61,10 @@ defmodule Joken.Token.Test do
     new_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.3fazvmF342WiHp5uhY-wkWArn-YJxq1IO7Msrtfk-OD"
     {:error, mesg} = Joken.Token.decode(@secret, @poison_json_module, new_token) 
     assert(mesg == "Invalid signature") 
+  end
+
+  test "signature validation unsorted payload (Poison)" do
+    assert {:ok, mesg} = Joken.Token.decode(@secret, @poison_json_module, @unsorted_payload_token)
   end
 
   test "expiration (exp)" do


### PR DESCRIPTION
So this is an issue I ran into where my JWTs which are generated by Auth0.com are being rejected for invalid signatures.

Essentially I could do this:

```elixir

#jwt generated at jwt.io
jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tLyIsInN1YiI6ImV4YW1wbGV8MTIzNDU2IiwiYXVkIjoiYWJjMTIzIiwiaWF0IjoxNDI4MzcxMTg4fQ.w9Elb3Ogomd1hm0bAvjbrOPIDhZhgOxckG_ztDJVhJs"

new_jwt = jwt
|> Joken.Utils.base64url_decode
|> Joken.TestPoison.decode
|> Joken.TestPoison.encode
|> Joken.Utils.base64url_encode

# This should be the same, so the same signature can be generated, but it isn't.
assert jwt != new_jwt
```

I added two commits, one with a failing test demonstrating the issue with a token generated at jwt.io, the other with my attempt at a fix which uses the original header and payload in the signature verification process.
