### PR TITLE
Add `iat` claim support to behave the same as `nbf`.

### DIFF
--- a/lib/joken/claims.ex
+++ b/lib/joken/claims.ex
@@ -44,6 +44,14 @@ defmodule Joken.Claims do
     error
   end
 
+  def check_iat({:ok, payload}) do
+    check_time_claim({:ok, payload}, :iat, "Token not valid yet", fn(not_before, now) -> not_before < now end)
+  end
+
+  def check_iat(error) do
+    error
+  end
+
   def check_time_claim({:ok, payload}, key, error_msg, validate_time_fun) do
     key_found? = case payload do
       p when is_map(p) ->

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -54,6 +54,7 @@ defmodule Joken.Token do
     |> Claims.check_signature(secret_key, algorithm, token)
     |> Claims.check_exp
     |> Claims.check_nbf
+    |> Claims.check_iat
     |> Claims.check_aud(Map.get(claims, :aud, nil))
     |> Claims.check_iss(Map.get(claims, :iss, nil))
     |> Claims.check_sub(Map.get(claims, :sub, nil))

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -78,6 +78,14 @@ defmodule Joken.Token.Test do
     assert(mesg == "Token expired") 
   end
 
+  test "valid iat claim" do
+    {:ok, token} = Joken.Token.encode(@secret, @poison_json_module, @payload, :HS256, %{ iat: Joken.Utils.get_current_time() - 300 })
+    assert {:ok, _} = Joken.Token.decode(@secret, @poison_json_module, token, :HS256)
+
+    {:ok, token} = Joken.Token.encode(@secret, @poison_json_module, @payload, :HS256, %{ iat: Joken.Utils.get_current_time() + 300 })
+    assert {:error, "Token not valid yet"} = Joken.Token.decode(@secret, @poison_json_module, token, :HS256)
+  end
+
   test "error with invalid algorithm" do
     {:error, message} = Joken.Token.encode(@secret, @poison_json_module, @payload, :HS1024)
     assert message == "Unsupported algorithm"


### PR DESCRIPTION
The spec doesn't really have a lot to say about this:
https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.6

This implimentation follows the pattern the Ruby JWT impliments for this
claim:
https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.6

Closes #8