### PR TITLE
Allow up to 60 clock skew when validating iat/nbf.

### DIFF
--- a/lib/joken/claims.ex
+++ b/lib/joken/claims.ex
@@ -2,6 +2,8 @@ defmodule Joken.Claims do
   alias Joken.Utils
   @moduledoc false
 
+  @clock_skew 60 #seconds
+
   def check_exp({:ok, payload}) do
     check_time_claim({:ok, payload}, :exp, "Token expired", fn(expires_at, now) -> expires_at > now end)
   end
@@ -11,7 +13,7 @@ defmodule Joken.Claims do
   end
 
   def check_nbf({:ok, payload}) do
-    check_time_claim({:ok, payload}, :nbf, "Token not valid yet", fn(not_before, now) -> not_before < now end) 
+    check_time_claim({:ok, payload}, :nbf, "Token not valid yet", fn(not_before, now) -> not_before - @clock_skew < now end) 
   end
 
   def check_nbf(error) do
@@ -19,7 +21,7 @@ defmodule Joken.Claims do
   end
 
   def check_iat({:ok, payload}) do
-    check_time_claim({:ok, payload}, :iat, "Token not valid yet", fn(not_before, now) -> not_before < now end)
+    check_time_claim({:ok, payload}, :iat, "Token not valid yet", fn(not_before, now) -> not_before - @clock_skew < now end)
   end
 
   def check_iat(error) do

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -82,6 +82,10 @@ defmodule Joken.Token.Test do
     {:ok, token} = Joken.Token.encode(@secret, @poison_json_module, @payload, :HS256, %{ iat: Joken.Utils.get_current_time() - 300 })
     assert {:ok, _} = Joken.Token.decode(@secret, @poison_json_module, token, :HS256)
 
+    # up to 60 seconds clock skew okay
+    {:ok, token} = Joken.Token.encode(@secret, @poison_json_module, @payload, :HS256, %{ iat: Joken.Utils.get_current_time() + 55 })
+    assert {:ok, _} = Joken.Token.decode(@secret, @poison_json_module, token, :HS256)
+
     {:ok, token} = Joken.Token.encode(@secret, @poison_json_module, @payload, :HS256, %{ iat: Joken.Utils.get_current_time() + 300 })
     assert {:error, "Token not valid yet"} = Joken.Token.decode(@secret, @poison_json_module, token, :HS256)
   end


### PR DESCRIPTION
This is okay per spec:
https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.5


I have been occasionally getting token not valid yet errors. Personally I blame Elixir for being too fast :-D