### PR TITLE
Fixed issue where verify_signature verified tokens without a signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.13.1
+  * Enhancements
+    * Checking to make sure signature is on token unless `:none` is passed as the algorithm
+
 # v0.13.0
 
 * Enhancements

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -64,7 +64,11 @@ defmodule Joken.Token do
   defp verify_signature(token, key, algorithm) do
     case String.split(token, ".") do
       [ _header64, _payload64 ] ->
-        { :ok, token }
+          if algorithm == :none || is_nil(algorithm) do
+            { :ok, token }
+          else
+            { :error, "Missing signature" }
+          end
       [ header64, payload64, jwt_signature ] ->
         signature = :crypto.hmac(Utils.supported_algorithms[algorithm], key, "#{header64}.#{payload64}")
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Joken.Mixfile do
 
   def project do
     [app: :joken,
-     version: "0.13.0",
+     version: "0.13.1",
      elixir: "~> 1.0.0",
      description: description,
      package: package,

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -115,6 +115,20 @@ defmodule Joken.Token.Test do
     assert(@payload == decoded_payload) 
   end
 
+  test "missing signature" do
+    {:ok, token} = Joken.Token.encode(@secret, @jsx_json_module, @payload, :HS512)
+    assert(token == "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.zi1zohSNwRdHftnWKE16vE3VmbGFtG27LxbYDXAodVlX7T3ATgmJJPjluwf2SPKJND2-O7alOq8NWv6EAnWWyg")
+
+    {:error, message} = Joken.Token.decode(@secret, @jsx_json_module, "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ", :HS512) 
+    assert("Missing signature" == message) 
+  end
+
+  test "unsecure token" do
+    {status, decoded_payload} = Joken.Token.decode(@secret, @jsx_json_module, "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ", :none) 
+    assert(status == :ok) 
+    assert(decoded_payload == @payload)
+  end
+
   test "decode token generated with un-sorted keys (JSX)" do
     {:ok, _} = Joken.Token.encode(@secret, @jsx_json_module, @payload)
     {:ok, decoded_payload} = Joken.Token.decode(@secret, @jsx_json_module, @unsorted_header_token) 


### PR DESCRIPTION
Unsecured tokens are allowed if :none is passed in as the algorithm