### PR TITLE
Remove the none algorithm

### DIFF
--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -63,12 +63,7 @@ defmodule Joken.Token do
 
   defp verify_signature(token, key, algorithm) do
     case String.split(token, ".") do
-      [ _header64, _payload64 ] ->
-          if algorithm == :none || is_nil(algorithm) do
-            { :ok, token }
-          else
-            { :error, "Missing signature" }
-          end
+      [ _header64, _payload64 ] -> { :error, "Missing signature" }
       [ header64, payload64, jwt_signature ] ->
         signature = :crypto.hmac(Utils.supported_algorithms[algorithm], key, "#{header64}.#{payload64}")
 

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -128,9 +128,9 @@ defmodule Joken.Token.Test do
   end
 
   test "unsecure token" do
-    {status, decoded_payload} = Joken.Token.decode(@secret, @jsx_json_module, "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ", :none) 
-    assert(status == :ok) 
-    assert(decoded_payload == @payload)
+    {status, message} = Joken.Token.decode(@secret, @jsx_json_module, "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ", :none)
+    assert(status == :error)
+    assert(message == "Missing signature")
   end
 
   test "decode token generated with un-sorted keys (JSX)" do


### PR DESCRIPTION
The none algorithm allows for simple forging of tokens and should not be
used

See https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/