### PR TITLE
Added options to decode to pass skip

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -59,11 +59,17 @@ defmodule Joken do
   Decodes the given JSON Web Token and gets the payload
 
       Joken.decode(token)
+
+  You can also pass a skip list of atoms in order to skip some validations.
+  Be advised that this is NOT intended to customize claim validation. It is
+  is only intended to be used when you want to refresh a token and need to
+  validate an expired token.
   """
 
-  @spec decode(String.t) :: { status, map | String.t }
-  def decode(jwt) do
-    Token.decode(secret_key, parameters_module, jwt, algorithm)
+  @spec decode(String.t, Keyword.t) :: { status, map | String.t }
+  def decode(jwt, options \\ []) do
+    skip_options = Keyword.get options, :skip, []
+    Token.decode(secret_key, parameters_module, jwt, algorithm, skip_options)
   end
 
   defp secret_key() do

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -372,9 +372,16 @@ defmodule Joken.Test do
     assert(mesg == "Missing subject")  
   end
 
-  test "malformed token"do
+  test "malformed token" do
     {status, _} = Joken.decode("foobar")
     assert(status == :error)
-  end 
+  end
+
+  test "claim skipping" do
+    expiration = Joken.Utils.get_current_time() - 100000
+    {:ok, expired_token} = Joken.encode(Map.put(@payload, :exp, expiration))
+    {status, _} = Joken.decode expired_token, skip: [:exp]
+    assert(status == :ok)
+  end
   
 end


### PR DESCRIPTION
This is related to Issue #31. There was no easy way to pass options to decode using Joken module. Also added a test for the skip functionality that was missing. This might conflict with the previous PR because it cleaned up docs. This is based on your master so if you want me to rebase it or change anything just leave a comment \o/

Cheers,