### PR TITLE
Allow structs to be encoded to tokens

### DIFF
--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -46,6 +46,9 @@ defmodule Joken.Token do
     end
   end
 
+  defp get_payload_json(%{__struct__: _mod} = payload, claims, json_module) do
+    get_payload_json(Map.from_struct(payload), claims, json_module)
+  end
   defp get_payload_json(payload, claims, json_module) do
     try do
       { :ok, Dict.merge(payload, claims) |> json_module.encode }


### PR DESCRIPTION
This is a really small change just to allow structs to be encoded as JSON. This is helpful if you plan to keep your tokens in a Database (and map them with ecto or something like that). Here I only avoid calling Dict.merge in a struct. This is so small that I haven't even created an issue to reference here... sorry!