### PR TITLE
Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false # to use faster container based build environment
+language: elixir
+elixir:
+  - 1.0.5
+otp_release:
+  - 17.5
+  - 18.0
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix docs # generate docs to check if it is not breaking.

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,4 +21,6 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-     import_config "#{Mix.env}.exs"
+unless Mix.env == :docs do
+  import_config "#{Mix.env}.exs"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -16,13 +16,12 @@ defmodule Joken.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.7", only: :dev},
+      {:earmark, "~> 0.1", only: :docs},
+      {:ex_doc, "~> 0.7", only: :docs},
       {:poison, "~> 1.3", only: :test},
       {:jsx, "~> 2.1.1",  only: :test}
     ]
   end
-
 
   defp description do
     """
@@ -32,11 +31,11 @@ defmodule Joken.Mixfile do
 
   defp package do
     [
-     files: ["lib", "priv", "mix.exs", "README*", "readme*", "LICENSE*", "license*", "CHANGELOG*"],
-     contributors: ["Bryan Joseph"],
-     licenses: ["Apache 2.0"],
-     links: %{"GitHub" => "https://github.com/bryanjos/joken",
-              "Docs" => "https://github.com/bryanjos/joken"}
+      files: ["lib", "priv", "mix.exs", "README*", "readme*", "LICENSE*", "license*", "CHANGELOG*"],
+      contributors: ["Bryan Joseph"],
+      licenses: ["Apache 2.0"],
+      links: %{"GitHub" => "https://github.com/bryanjos/joken",
+               "Docs" => "http://hexdocs.pm/joken"}
     ]
   end
 end


### PR DESCRIPTION
This implements #49. It also fixes docs dependencies scope and link. This is because docs will be built everytime tests are run to check if new code is not breaking docs generation. 

Maybe this is not the best alternative, but for now I am simply skipping adding a config file for env docs. 

Currently I have enabled only elixir 1.0.5 on Erlang/OTP 17.5 and 18. I don't think that currently we need more than that.

Cheers!

