### PR TITLE
Fixed struct encoding/decoding and added tests for this use case

### DIFF
--- a/lib/joken/helpers.ex
+++ b/lib/joken/helpers.ex
@@ -4,20 +4,21 @@ defmodule Joken.Helpers do
   Helper function for validating time claims (exp, nbf, iat)
   """
   def validate_time_claim(payload, key, error_msg, validate_time_fun) do
+    
     key_found? = Dict.has_key?(payload, key)
     value = Dict.get(payload, key)
     current_time = get_current_time()
+    result = validate_time_fun.(value, current_time)
 
     cond do
-      key_found? and validate_time_fun.(value, current_time) ->
+      key_found? and result ->
         :ok
-      key_found? and !validate_time_fun.(value, current_time) ->
+      key_found? and !result ->
         {:error, error_msg}
       true ->
         :ok
     end
   end
-
 
   @doc """
   Helper function for validating non-time claims

--- a/lib/joken/helpers.ex
+++ b/lib/joken/helpers.ex
@@ -3,8 +3,12 @@ defmodule Joken.Helpers do
   @doc """
   Helper function for validating time claims (exp, nbf, iat)
   """
+  def validate_time_claim(%{__struct__: _module} = payload, key, error_msg, validate_time_fun) do
+    validate_time_claim(Map.from_struct(payload), key, error_msg, validate_time_fun)
+  end
+
   def validate_time_claim(payload, key, error_msg, validate_time_fun) do
-    
+
     key_found? = Dict.has_key?(payload, key)
     value = Dict.get(payload, key)
     current_time = get_current_time()
@@ -23,6 +27,10 @@ defmodule Joken.Helpers do
   @doc """
   Helper function for validating non-time claims
   """
+  def validate_claim(%{__struct__: _mod} = payload, key_to_check, value, full_name) do
+    validate_claim(Map.from_struct(payload), key_to_check, value, full_name)
+  end
+  
   def validate_claim(payload, key_to_check, value, full_name) do
     key_found? = Dict.has_key?(payload, key_to_check)
     the_value = Dict.get(payload, key_to_check)

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -13,7 +13,6 @@ defmodule Joken.Token do
   def encode(joken_config, payload) do
     headerJSON = joken_config.encode(%{ alg: to_string(joken_config.algorithm), typ: :JWT })
 
-
     claims = Enum.reduce(@claims, %{}, fn(claim, current_claims) ->
       result = joken_config.claim(claim, payload)
 
@@ -23,7 +22,6 @@ defmodule Joken.Token do
         current_claims
       end
     end)
-
 
     {status, payloadJSON} = get_payload_json(payload, claims, joken_config)
 
@@ -74,10 +72,10 @@ defmodule Joken.Token do
       _ ->
         {:ok, data} = get_data(token, joken_config)
 
-       results = claims ++ Dict.keys(options)
+        results = claims ++ Dict.keys(options)
         |> Enum.uniq
         |> Enum.map(fn(claim) ->
-          joken_config.validate_claim(claim, data, options)
+           joken_config.validate_claim(claim, data, options)
         end)
         |> Enum.filter(fn(result) ->
           case result do
@@ -121,6 +119,8 @@ defmodule Joken.Token do
     data = Utils.base64url_decode(payload64)
     {:ok, joken_config.decode(data) }
   end
+
+  defp to_map(%{__struct__: _mod} = struct), do: struct
 
   defp to_map(keywords) do
     keywords |> Enum.into(%{})

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -3,6 +3,25 @@ defmodule Joken.Test do
   
   @payload %{ name: "John Doe" }
 
+  defmodule BaseConfig do
+
+    defmacro __using__(_opts) do
+      quote do
+        @behaviour Joken.Config
+
+        def secret_key(), do: "test"
+        def algorithm(), do: :HS256
+        def encode(map), do: Poison.encode!(map)
+        def decode(binary), do: Poison.decode!(binary, keys: :atoms!)
+        def claim(_claim, _payload), do: nil
+        def validate_claim(_claim, _payload, _options), do: :ok
+
+        defoverridable algorithm: 0, encode: 1, decode: 1, claim: 2, validate_claim: 3
+      end
+    end
+    
+  end
+  
   test "signature validation"do
     Application.put_env(:joken, :config_module, Joken.TestPoison)
 
@@ -17,24 +36,7 @@ defmodule Joken.Test do
 
   test "expiration (exp) success" do
     defmodule ExpSuccessTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
-
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
+      use BaseConfig
 
       def claim(:exp, _payload) do
         Joken.Helpers.get_current_time() + 300
@@ -62,40 +64,20 @@ defmodule Joken.Test do
 
   test "expiration (exp) failure" do
     defmodule ExpFailureTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
-
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
+      use BaseConfig
 
       def claim(:exp, _payload) do
         Joken.Helpers.get_current_time() - 300
       end
 
-      def claim(_, _payload) do
-        nil
-      end
+      def claim(_, _payload), do: nil
 
       def validate_claim(:exp, payload, _) do
         Joken.Helpers.validate_time_claim(payload, :exp, "Token expired", fn(expires_at, now) -> expires_at > now end)
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
+
     end 
 
     Application.put_env(:joken, :config_module, ExpFailureTest)
@@ -108,44 +90,22 @@ defmodule Joken.Test do
 
   test "not before (nbf) success" do
     defmodule NbfSuccessTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
-
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
+      use BaseConfig
 
       def claim(:nbf, _payload) do
         Joken.Helpers.get_current_time() - 300
       end
 
-      def claim(_, _payload) do
-        nil
-      end
+      def claim(_, _payload), do: nil
 
       def validate_claim(:nbf, payload, _) do
         Joken.Helpers.validate_time_claim(payload, :nbf, "Token not valid yet", fn(not_before, now) -> not_before < now end) 
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, NbfSuccessTest)
-
 
     {:ok, token} = Joken.encode(@payload)
     {status, _} = Joken.decode(token)
@@ -153,42 +113,21 @@ defmodule Joken.Test do
   end
 
   test "not before (nbf) failure" do
+
     defmodule NbfFailureTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
-
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
+      use BaseConfig
 
       def claim(:nbf, _payload) do
         Joken.Helpers.get_current_time() + 300
       end
 
-      def claim(_, _payload) do
-        nil
-      end
+      def claim(_, _payload), do: nil
 
       def validate_claim(:nbf, payload, _) do
         Joken.Helpers.validate_time_claim(payload, :nbf, "Token not valid yet", fn(not_before, now) -> not_before < now end) 
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, NbfFailureTest)
@@ -201,36 +140,11 @@ defmodule Joken.Test do
 
   test "audience (aud) success" do
     defmodule AudSuccessTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(:aud, _payload) do
-        "Test"
-      end
-
-      def claim(_, _payload) do
-        nil
-      end
-
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def claim(:aud, _payload), do: "Test"
+      def claim(_, _payload), do: nil
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, AudSuccessTest)
@@ -243,40 +157,16 @@ defmodule Joken.Test do
 
   test "audience (aud) invalid" do
     defmodule InvalidAudienceTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(:aud, _payload) do
-        "Test"
-      end
-
-      def claim(_, _payload) do
-        nil
-      end
+      def claim(:aud, _payload), do: "Test"
+      def claim(_, _payload), do: nil
 
       def validate_claim(:aud, _payload, _) do
         {:error, "Invalid audience"}
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, InvalidAudienceTest)
@@ -289,40 +179,16 @@ defmodule Joken.Test do
 
   test "audience (aud) missing" do
     defmodule MissingAudienceTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
-
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(:aud, _payload) do
-        "Test"
-      end
-
-      def claim(_, _payload) do
-        nil
-      end
+      use BaseConfig
+      
+      def claim(:aud, _payload), do: "Test"
+      def claim(_, _payload), do: nil
 
       def validate_claim(:aud, _payload, _) do
         {:error, "Missing audience"}
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, MissingAudienceTest)
@@ -335,36 +201,12 @@ defmodule Joken.Test do
 
   test "subject (sub) success" do
     defmodule SubSuccessTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
+      def claim(:sub, _payload), do: "Test"
+      def claim(_, _payload), do: nil
 
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(:sub, _payload) do
-        "Test"
-      end
-
-      def claim(_, _payload) do
-        nil
-      end
-
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, SubSuccessTest)
@@ -381,40 +223,19 @@ defmodule Joken.Test do
 
   test "claim skipping" do
     defmodule ExpSkippedTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
-
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
+      use BaseConfig
 
       def claim(:exp, _payload) do
         Joken.Helpers.get_current_time() - 100000
       end
 
-      def claim(_, _payload) do
-        nil
-      end
+      def claim(_, _payload), do: nil
 
       def validate_claim(:exp, payload, _) do
         Joken.Helpers.validate_time_claim(payload, :exp, "Token expired", fn(expires_at, now) -> expires_at > now end)
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, ExpSkippedTest)
@@ -426,32 +247,10 @@ defmodule Joken.Test do
 
   test "passing in extra data" do
     defmodule ExtraDataTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(:aud, _payload) do
-        "update"
-      end
-
-      def claim(_, _payload) do
-        nil
-      end
+      def claim(:aud, _payload), do: "update"
+      def claim(_, _payload), do: nil
 
       def validate_claim(:aud, payload, options) do
         if Dict.get(options, :aud) == Dict.get(payload, :aud) do
@@ -462,9 +261,7 @@ defmodule Joken.Test do
         
       end
 
-      def validate_claim(_, _payload, _) do
-        :ok
-      end
+      def validate_claim(_, _payload, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, ExtraDataTest)
@@ -476,28 +273,9 @@ defmodule Joken.Test do
 
   test "validate custom claim from options" do
     defmodule CustomClaimTest do
-      alias Poison, as: JSON
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        JSON.encode!(map)
-      end
-
-      def decode(binary) do
-        JSON.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(_, _) do
-        nil
-      end
+      def claim(_, _), do: nil
 
       def validate_claim(:user_id, payload, options) do
         if Dict.get(options, :user_id) == Dict.get(payload, :user_id) do
@@ -508,9 +286,7 @@ defmodule Joken.Test do
         
       end
 
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def validate_claim(_, _, _), do: :ok
     end 
 
     Application.put_env(:joken, :config_module, CustomClaimTest)
@@ -520,7 +296,29 @@ defmodule Joken.Test do
 
     {status, _} = Joken.decode token, [user_id: "cba"]
     assert(status == :error)
+  end
 
+  defmodule StructToken do
+    use BaseConfig
+
+    defstruct nbf: nil
+
+    def decode(binary), do: Poison.decode!(binary, keys: :atoms!, as: Joken.Test.StructToken)
+    
+    def validate_claim(:nbf, payload, _) do
+      Joken.Helpers.validate_time_claim(payload, :nbf, "Token not valid yet",
+        fn(not_before, now) ->
+           not_before < now
+        end) 
+    end
+
+    def validate_claim(_, _payload, _), do: :ok
+  end
+  
+  test "encode a struct" do
+
+    {:ok, token} = Joken.encode(%StructToken{nbf: Joken.Helpers.get_current_time() - 300})
+    {:ok, token} = Joken.decode(token)
   end
   
 end

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -4,7 +4,6 @@ defmodule Joken.Token.Test do
   @moduledoc """
   Tests calling the Joken.Token module directly
   """
-
   @secret "test"
   @payload %{ name: "John Doe" }
 
@@ -23,6 +22,27 @@ defmodule Joken.Token.Test do
   @poison_json_module Joken.TestPoison
   @jsx_json_module Joken.TestJsx
 
+  # base config that is overriden in each test
+  defmodule BaseConfig do
+
+    @moduledoc false
+
+    defmacro __using__(_opts) do
+      quote do
+        @behaviour Joken.Config
+
+        def secret_key(), do: "test"
+        def algorithm(), do: :HS256
+        def encode(map), do: Poison.encode!(map)
+        def decode(binary), do: Poison.decode!(binary, keys: :atoms!)
+        def claim(_claim, _payload), do: nil
+        def validate_claim(_claim, _payload, _options), do: :ok
+
+        defoverridable [algorithm: 0, encode: 1, decode: 1, claim: 2, validate_claim: 3]
+      end
+    end
+  end
+  
   test "encode and decode with HS256 (Poison)" do
     {:ok, token} = Joken.Token.encode(@poison_json_module, @payload)
     assert(token == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.B3tqUk6UdT8K5AQUGdYFXPj7R7_JznRi5PRrv_N7d1I")
@@ -32,32 +52,11 @@ defmodule Joken.Token.Test do
   end
 
   test "encode and decode with HS384 (Poison)" do
+
     defmodule Decode384 do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS384
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def algorithm(), do: :HS384
     end
 
     {:ok, token} = Joken.Token.encode(Decode384, @payload)
@@ -68,32 +67,11 @@ defmodule Joken.Token.Test do
   end
 
   test "encode and decode with HS512 (Poison)" do
+
     defmodule Decode512 do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS512
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def algorithm(), do: :HS512
     end
 
     {:ok, token} = Joken.Token.encode(Decode512, @payload)
@@ -123,34 +101,12 @@ defmodule Joken.Token.Test do
     assert {:ok, _} = Joken.Token.decode(@poison_json_module, @unsorted_payload_token)
   end
 
-
   test "error with invalid algorithm" do
+
     defmodule Decode1024 do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS1024
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary, keys: :atoms!)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def algorithm(), do: :HS1024
     end
 
     {:error, message} = Joken.Token.encode(Decode1024, @payload)
@@ -167,31 +123,15 @@ defmodule Joken.Token.Test do
 
   test "encode and decode with HS384 (JSX)" do
     defmodule TestJsx384 do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
+      def algorithm(), do: :HS384
 
-      def algorithm() do
-        :HS384
-      end
-
-      def encode(map) do
-        :jsx.encode(map)
-      end
+      def encode(map), do: :jsx.encode(map)
 
       def decode(binary) do
         :jsx.decode(binary)
         |> Enum.map(fn({key, value})-> {String.to_atom(key), value} end)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
       end
     end
 
@@ -203,32 +143,17 @@ defmodule Joken.Token.Test do
   end
 
   test "encode and decode with HS512 (JSX)" do
+
     defmodule TestJsx512 do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
+      def algorithm(), do: :HS512
 
-      def algorithm() do
-        :HS512
-      end
-
-      def encode(map) do
-        :jsx.encode(map)
-      end
+      def encode(map), do: :jsx.encode(map)
 
       def decode(binary) do
         :jsx.decode(binary)
         |> Enum.map(fn({key, value})-> {String.to_atom(key), value} end)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
       end
     end
 
@@ -240,32 +165,17 @@ defmodule Joken.Token.Test do
   end
 
   test "missing signature" do
+
     defmodule TestJsx512Missing do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
+      def algorithm(), do: :HS512
 
-      def algorithm() do
-        :HS512
-      end
-
-      def encode(map) do
-        :jsx.encode(map)
-      end
+      def encode(map), do: :jsx.encode(map)
 
       def decode(binary) do
         :jsx.decode(binary)
         |> Enum.map(fn({key, value})-> {String.to_atom(key), value} end)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
       end
     end
 
@@ -278,31 +188,15 @@ defmodule Joken.Token.Test do
 
   test "unsecure token" do
     defmodule TestJsxNone do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
+      def algorithm(), do: :none
 
-      def algorithm() do
-        :none
-      end
-
-      def encode(map) do
-        :jsx.encode(map)
-      end
+      def encode(map), do: :jsx.encode(map)
 
       def decode(binary) do
         :jsx.decode(binary)
         |> Enum.map(fn({key, value})-> {String.to_atom(key), value} end)
-      end
-
-      def claim(_, _) do
-        nil
-      end
-
-      def validate_claim(_, _, _) do
-        :ok
       end
     end
 
@@ -329,75 +223,39 @@ defmodule Joken.Token.Test do
 
   test "expiration (exp)" do
     defmodule ExpSuccessTest do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary)
-      end
-
+      def decode(binary), do: Poison.decode!(binary)
+      
       def claim(:exp, _payload) do
         Joken.Helpers.get_current_time() + 300
       end
 
-      def claim(_, _) do
-        nil
-      end
+      def claim(_, _), do: nil
 
       def validate_claim(:exp, payload) do
-        Joken.Config.validate_time_claim(payload, "exp", "Token expired", fn(expires_at, now) -> expires_at > now end)
+        Joken.Helpers.validate_time_claim(payload, "exp", "Token expired", fn(expires_at, now) -> expires_at > now end)
       end
 
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def validate_claim(_, _, _), do: :ok
     end
 
     defmodule ExpFailureTest do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary)
-      end
-
+      def decode(binary), do: Poison.decode!(binary)
+      
       def claim(:exp, _payload) do
         Joken.Helpers.get_current_time() - 300
       end
 
-      def claim(_, _) do
-        nil
-      end
+      def claim(_, _), do: nil
 
       def validate_claim(:exp, payload, _) do
         Joken.Helpers.validate_time_claim(payload, "exp", "Token expired", fn(expires_at, now) -> expires_at > now end)
       end
 
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def validate_claim(_, _, _), do: :ok
     end 
 
     {:ok, token} = Joken.Token.encode(ExpSuccessTest,  %{ "name" => "John Doe" })
@@ -411,76 +269,42 @@ defmodule Joken.Token.Test do
   end
 
   test "valid iat claim" do
+
     defmodule IatSuccessTest do
-      @behaviour Joken.Config
+      use BaseConfig
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary)
-      end
-
+      def decode(binary), do: Poison.decode!(binary)
+      
       def claim(:iat, _payload) do
         Joken.Helpers.get_current_time() - 300
       end
 
-      def claim(_, _) do
-        nil
-      end
+      def claim(_, _), do: nil
 
       def validate_claim(:iat, payload) do
-        Joken.Config.validate_time_claim(payload, "iat", "Token not valid yet", fn(not_before, now) -> not_before < now end) 
+        Joken.Config.validate_time_claim(payload, "iat", "Token not valid yet", &(&1 < &2)) 
       end
 
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def validate_claim(_, _, _), do: :ok
     end
 
     defmodule IatFailureTest do
-      @behaviour Joken.Config
+      use BaseConfig
+      require Logger
 
-      def secret_key() do
-        "test"
-      end
-
-      def algorithm() do
-        :HS256
-      end
-
-      def encode(map) do
-        Poison.encode!(map)
-      end
-
-      def decode(binary) do
-        Poison.decode!(binary)
-      end
-
+      def decode(binary), do: Poison.decode!(binary)
+      
       def claim(:iat, _payload) do
         Joken.Helpers.get_current_time() + 300
       end
 
-      def claim(_, _) do
-        nil
-      end
+      def claim(_, _), do: nil
 
       def validate_claim(:iat, payload, _) do
-        Joken.Helpers.validate_time_claim(payload, "iat", "Token not valid yet", fn(not_before, now) -> not_before < now end) 
+        Joken.Helpers.validate_time_claim(payload, "iat", "Token not valid yet", &(&1 < &2))
       end
 
-      def validate_claim(_, _, _) do
-        :ok
-      end
+      def validate_claim(_, _, _), do: :ok
     end 
 
     {:ok, token} = Joken.Token.encode(IatSuccessTest,  %{ "name" => "John Doe" })


### PR DESCRIPTION
This fixes the struct handling in Joken.Token and Joken.Helpers. With this PR struct encoding is properly working again. I added tests to ensure this won't break in future PRs.

Since I was adding tests I introduced a BaseConfig module in each test file to save lines. Each test does not need to add all config options over and over again. It just needs to create a module that uses the BaseConfig and overrides the callbacks it needs to test. If you don't want this behaviour I'll close this PR  and open a struct fixing only PR.