### PR TITLE
Joken plug

### DIFF
--- a/lib/joken/plug.ex
+++ b/lib/joken/plug.ex
@@ -1,0 +1,136 @@
+defmodule Joken.Plug do
+
+  @moduledoc """
+  A Plug for signing and verifying authentication tokens.
+
+  ## Usage
+  
+  There are two possible scenarios:
+
+  1. Same configuration for all routes
+  2. Per route configuration
+
+  In the first scenario just add this plug before the dispatch plug.
+
+      defmodule MyRouter do
+        use Plug.Router
+
+        plug Joken.Plug, config_module: MyJWTConfig
+        plug :match
+        plug :dispatch
+
+        post "/user" do
+          # will only execute here if token is present and valid
+        end
+
+        match _ do
+          # will only execute here if token is present and valid
+        end
+      end
+
+  In the second scenario, you will need at least plug ~> 0.14 in your deps. 
+  Then you must plug this AFTER :match and BEFORE :dispatch. 
+
+      defmodule MyRouter do
+        use Plug.Router
+
+        # route options
+        @skip_token_verification %{joken_skip: true}
+
+        plug :match
+        plug Joken.Plug, config_module: MyJWTConfig        
+        plug :dispatch
+
+        post "/user" do
+          # will only execute here if token is present and valid
+        end
+        
+        # see options section below
+        match _, private: @skip_token_verification do
+          # will NOT try to validate a token
+        end
+      end
+
+  ## Options
+
+  This plug accepts the following options in its initialization:
+
+  - `config_module`: the `Joken.Config` implementation
+  - `error_map` (optional): a function that will be called with the error message
+  and must return a map. The resulting map is going to be encoded to JSON and put in the body
+  of all 401 responses.
+
+  When using this with per route options you must pass a private map of options
+  to the route. The keys that Joken will look for in that map are:
+
+  - `joken_skip`: skips token validation
+  - `joken_opts`: pass this as a third parameter to `Joken.Token.decode/3`
+  - `joken_evaluate`: a custom function that will be called if token is valid. 
+  It will be passed the payload as the only argument and if its return is falsy, a 401 
+  reply will be sent and execution is halted.
+  """
+  import Plug.Conn
+  
+  @doc false
+  def init(opts) do
+    config_module = Keyword.get(opts, :config_module, Application.get_env(:joken, :config_module))
+    {config_module}
+  end
+
+  @doc false
+  def call(conn, {config_module}) do
+
+    conn = put_private(conn, :joken_config_module, config_module)
+    
+    if Map.get(conn.private, :joken_skip, false) do
+      conn
+    else
+      parse_auth(conn, get_req_header(conn, "authorization"))
+    end
+  end
+
+  def encode(conn, claims) do
+    {:ok, token} = Joken.Token.encode(conn.private[:joken_config_module], claims)
+    token
+  end
+
+  def error_map(description, status) do
+    %{error: "Unauthorized",
+      description: description,
+      status_code: status}
+  end
+
+  defp parse_auth(conn, ["Bearer " <> token]) do
+    options = Map.get(conn.private, :joken_opts, [])
+    decoded = Joken.Token.decode(conn.private[:joken_config_module], token, options)
+    evaluate(conn, decoded)
+  end
+  defp parse_auth(conn, _header) do
+    send_401(conn, "Unauthorized")
+  end
+
+  defp evaluate(conn, {:ok, payload}) do
+
+    conn = assign(conn, :joken_payload, payload)
+    
+    unless payload_fun = Map.get(conn.private, :joken_evaluate) do
+      conn
+    else
+      if payload_fun.(payload), do: conn, else: send_401(conn, "Unauthorized")
+    end
+  end
+  defp evaluate(conn, {:error, message}) do
+    send_401(conn, message)
+  end
+
+  defp send_401(conn, message) do
+    config_module = conn.private[:joken_config_module]
+    json = config_module.encode(error_map(message, 401))
+    
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> send_resp(401, json)
+    |> halt
+  end
+  
+end

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,7 @@ defmodule Joken.Mixfile do
 
   defp deps do
     [
+      {:plug, "~> 0.14", optional: true},
       {:earmark, "~> 0.1", only: :docs},
       {:ex_doc, "~> 0.7", only: :docs},
       {:poison, "~> 1.3", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.1"},
   "jsx": {:hex, :jsx, "2.1.1"},
+  "plug": {:hex, :plug, "0.14.0"},
   "poison": {:hex, :poison, "1.3.1"},
   "timex": {:hex, :timex, "0.13.3"}}

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -1,0 +1,122 @@
+defmodule JokenPlug.Test do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  defmodule MyConfig do
+    @behaviour Joken.Config
+
+    def secret_key(), do: "secret"
+    def algorithm(), do: :HS256
+    def encode(map), do: Poison.encode!(map)
+    def decode(binary), do: Poison.decode!(binary, keys: :atoms!)
+    def claim(:sub, _), do: 1234567890
+    def claim(_, _), do: nil
+    def validate_claim(_, _, _), do: :ok
+  end
+
+  defmodule MyPlugRouter do
+    use Plug.Router
+
+    @skip_auth %{joken_skip: true}
+    @is_subject %{joken_evaluate: &MyPlugRouter.is_subject/1 }
+    @is_not_subject %{joken_evaluate: &MyPlugRouter.is_not_subject/1 }
+
+    plug :match
+    plug Joken.Plug, config_module: MyConfig
+    plug :dispatch
+
+    post "/generate_token", private: @skip_auth do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(200, Joken.Plug.encode(conn, %{}))      
+    end
+      
+    get "/verify_token" do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(200, "Hello Tester")      
+    end
+
+    get "/skip_verification", private: @skip_auth do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(200, "Hello Tester")      
+    end
+
+    post "/custom_function_success", private: @is_subject do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(200, "I am subject 1234567890")
+    end
+
+    post "/custom_function_failure", private: @is_not_subject do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(200, "I am subject 1234567890")
+    end
+    
+    match _, private: @skip_auth do
+      conn
+      |> send_resp(404, "Not found")
+    end
+
+    def is_subject(payload), do: payload.sub == 1234567890
+    def is_not_subject(payload), do: payload.sub != 1234567890
+
+  end
+
+  test "generates token properly" do
+    conn = conn(:post, "/generate_token") |> MyPlugRouter.call([])
+    assert conn.status == 200
+
+    token = conn.resp_body
+    
+    conn = conn(:get, "/verify_token")
+    |> put_req_header("authorization", "Bearer " <> token)
+    |> MyPlugRouter.call([])
+
+    assert conn.status == 200
+    assert conn.resp_body == "Hello Tester"
+  end
+  
+  test "sends 401 when credentials are missing" do
+    conn = conn(:get, "/verify_token") |> MyPlugRouter.call([])
+    assert conn.status == 401
+    assert conn.resp_body == ~s({"status_code":401,"error":"Unauthorized","description":"Unauthorized"}) 
+  end
+
+  test "skips verification properly" do
+    conn = conn(:get, "/skip_verification") |> MyPlugRouter.call([])
+    assert conn.status == 200
+    assert conn.resp_body == "Hello Tester"
+  end
+
+  test "evaluates custom function for route (success)" do
+    conn = conn(:post, "/generate_token") |> MyPlugRouter.call([])
+    assert conn.status == 200
+
+    token = conn.resp_body
+    
+    conn = conn(:post, "/custom_function_success")
+    |> put_req_header("authorization", "Bearer " <> token)
+    |> MyPlugRouter.call([])
+
+    assert conn.status == 200
+    assert conn.resp_body == "I am subject 1234567890"
+  end
+
+  test "evaluates custom function for route (failure)" do
+    conn = conn(:post, "/generate_token") |> MyPlugRouter.call([])
+    assert conn.status == 200
+
+    token = conn.resp_body
+    
+    conn = conn(:post, "/custom_function_failure")
+    |> put_req_header("authorization", "Bearer " <> token)
+    |> MyPlugRouter.call([])
+
+    assert conn.status == 401
+    assert conn.resp_body == ~s({"status_code":401,"error":"Unauthorized","description":"Unauthorized"}) 
+  end
+
+end


### PR DESCRIPTION
This adds a plug to Joken. See #55 for more details. The differences from the issue's details are:
- the generate function is called encode.
- on_error and joken_evaluate can only receive Module.function/arity syntax. Check the tests for examples.