### PR TITLE
[WIP] - Added benchfella and first benchmark suite 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ erl_crash.dump
 *.ez
 /doc
 /docs
+/bench/snapshots

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ otp_release:
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix docs # generate docs to check if it is not breaking.
+  - MIX_ENV=test mix bench

--- a/bench/joken_token_bench.exs
+++ b/bench/joken_token_bench.exs
@@ -1,0 +1,204 @@
+defmodule Joken.Token.Bench do
+  use Benchfella
+  import Joken.Helpers
+  
+  defmodule BaseConfig do
+
+    def rsa_key do
+      %{"d" => "A2gHIUmJOzRGvklIA2S8wWayCXnF8NYAhOhu7woSwjioO3HRzvd3ptegSKDpPfABJuzhy7y08ug5ZcyFbN1hJBVY8NwNzpLSUK9wmXekrbTG9MT76NAiQTxV6fYK5DXPF4Cp0qghBt-tq0kQNKx4q9QEzLb9XonmXE2a10U8EWJIs972SFGhxKzf6aq6Ri7UDK607ngQyEhVmGxr3gDJLAGQ5wOap5NYIL2ufI5FYqH-Sby_Qk7299b-w4B0fl6u8isR8OlpwMLVnD-oqOBPH-65tE82hxPV0QbSmyzmg9hlVVinJ82YRBkbcu-XG9XXOhUqJJ7kafQrYkQx6BiFKQ",
+        "dp" => "Useg361ca8Aem1TToW8AfjOLAAEqkkR48UPMSS2Le9D4YFtAb_ud5CK2IevYl0R-4afXUzIoeiNRg4bOTAWmTwKKlmAp4B5GzlbPzAPhwQRCxzs5MiW0K-Nw30blBLWlJYDAnVEr3T3rqtgzXFLMhR5AHqM4VhWQK7QaxgaW7TE",
+        "dq" => "yueW-DmyJULJlJckFXfkivSO_X1sjQurDwDfyFLAnrvgy2EqJ-iq0gBVySMGw2CgeSQegTmuKinF4anL0wy85BK8tgxDULVOpjls4ej8ZQnJ2RVEjdxZLjKh-2yw-v6mbn7goko98nkRCBYMdDUBHNVcaY9bA8kdBWi-K6DgW2E",
+        "e" => "AQAB", "kty" => "RSA",
+        "n" => "xnAUUvtW3ftv25jCB-hePVCnhROqH2PACVGoCybdtMYTl8qVABAR0d6T-BRzVhJzz0-UvBNFUQyVvKAFxtbQUZN2JgAm08UJrDQszqz5tTzodWexODdPuoCaWaWge_MZGhz5PwWd7Jc4bPAu0QzSVFpBP3CovSjv48Z2Eq0_LHXVjjX_Az-WaUh94mXFyAxFI_oCygtT-il1-japS3cXJJh0WddT3VKEBRYHmxDJd_LYE-KXQt3aTDhq0vI9sG2ivtFj0dc3w_YBdr4hlcr42ujSP3wLTPpTjituwHQhYP4j-zqu7J3FYaIxU4lkK9Y_DP27RxffFI9YDPJdwFkNJw",
+        "p" => "5cMQg_4MrOnHI44xEs6Jyt_22DCvw3K-GY046Ls50vIf2KlRALHI65SPKfVFo5hUuHkBuWnQV46tHJU0dlmfg4svPMm_581r59yXeI8W6G4FlsSiVyhFO3P5Q5ubVs7MNaqhvaqqPqR14cVvHSqjwX5jGuGAVuLhnOhZGbtb7_U",
+        "q" => "3RlGNrCRU-yV7TTikKJVJCIpe8vgLBkHQ61iuICd8AyHa4sXICgf2YBFgW8CAJOHKIp8g_Nl94VYpqWvN1YVDB7sFUlRpJL2yXvTKxDzUwtM5pf_D1O6lGEMQBRY-buhZHmPf5qG93LnsSqm5YOZGpZ6t6gHtYM9A6JOIgwsYys",
+        "qi" => "kG5Stetls18_1fvQx8rxhX2Ais0Xg0gLDUjpE_9TYcb-utq79HVKOQ_2PJGz09hQ_teqnhXhgGMubqaktl6UOSJr6B4JgcAY7yU-34EuSxp8uKLix9BVsF2cpiC4ADhjLKP9c7IQ7X7zfs336_Reb8fh9G_zRdwEfmqFy7m28Lg"}
+    end
+
+    def ec_p256_key do
+      %{"crv" => "P-256", "d" => "aJhYDBNS-5yrH97PAExzWNLlJGqJwFGZmv7iJvdG4p0",
+        "kty" => "EC", "x" => "LksdLpZN3ijcn_TBfRK-_tgmvws0c5_V5k0bg14RLhU",
+        "y" => "ukc-JOEAWhW664SY5Q29xHlAVEDlrQwYF3-vQ_cdi1s"}
+    end
+
+    def ec_p384_key do
+      %{"crv" => "P-384",
+        "d" => "-iM1VuECCos2kAvvSXSsEGL-_A9-DIc4l8Z297xfSMSxiHJMYdyVMNRxHBmoJ__0",
+        "kty" => "EC",
+        "x" => "HgI0kaSfi-MJLcO5eP3OvLwO6pHYxiP4q-qnzqk5-TwR8MO9FweSRMpxWb-1buPZ",
+        "y" => "EdONZTBTmoT_c0R7_kSW6y_VaCgB_k2iNMlARR2xqFzVS5ADkyFtCEMgOS5JmZuA"}
+    end
+
+    def ec_p521_key do
+      %{"crv" => "P-521",
+        "d" => "ADa5GfibXsE1DcceEmsTB99lVG2cakh247L77aa1_K9OZrlYzCIhx-HVVzwJ-KDYPOIU9q2Up8D8H-EXM_6EOYzJ",
+        "kty" => "EC",
+        "x" => "ANrII7yaoz0vcvYKSXg404CebQYn0-GXIBvtc3hJFh-ubu8_mdIR6_B3pa3FC_CbHZnYcSxYeRaWmDjZmWqnWsgg",
+        "y" => "AH0EUWVaoVROX3_OzzQIZLuKG5546exe5-0cQ-E7thMaH6-k5cqcyIedCuX1c9lOWcXgo2NLlj4JOwSetCpOspEM"}
+    end
+
+    defmacro __using__(opts) do
+      quote do
+        @behaviour Joken.Config
+
+        @opts unquote(opts)
+        
+        def secret_key(), do: @opts[:key] || "test"
+        def algorithm(), do: @opts[:algorithm]
+        def encode(map), do: Poison.encode!(map)
+        def decode(binary), do: Poison.decode!(binary, keys: :atoms!)
+        def claim(:exp, _payload), do: get_current_time + 3000
+        def claim(:nbf, _payload), do: get_current_time - 300
+        def claim(:aud, _payload), do: "benchmark"
+        def claim(:iss, _payload), do: "joken benchmark"
+        def claim(:iat, _paylaod), do: get_current_time
+        def claim(_claim, _payload), do: nil
+        def validate_claim(:exp, payload, _opt) do
+          validate_time_claim(payload, :exp, "exp error", &(&1 > &2))
+        end
+        def validate_claim(:nbf, payload, _opt) do
+          validate_time_claim(payload, :nbf, "nbf error", &(&1 < &2))
+        end
+        def validate_claim(:iat, payload, _opt) do
+          validate_time_claim(payload, :iat, "iat error", &(&1 < &2))
+        end
+        def validate_claim(:aud, payload, _opt) do
+          validate_claim(payload, :aud, "benchmark", "audience")
+        end
+        def validate_claim(:iss, payload, _opt) do
+          validate_claim(payload, :iss, "joken benchmark", "iss")
+        end
+        def validate_claim(_claim, _payload, _options), do: :ok
+
+        defoverridable [secret_key: 0, algorithm: 0, encode: 1, decode: 1, claim: 2, validate_claim: 3]
+      end
+    end
+  end
+
+  ## ------------------------------
+  ## HS256, HS384, HS512 benchmarks
+  ## ------------------------------
+
+  defmodule HS256TokenGeneration do
+    use BaseConfig, algorithm: :HS256
+  end
+
+  defmodule HS384TokenGeneration do
+    use BaseConfig, algorithm: :HS384
+  end
+
+  defmodule HS512TokenGeneration do
+    use BaseConfig, algorithm: :HS512
+  end
+  
+  bench "HS256 token generation" do
+    {:ok, _token} = Joken.Token.encode HS256TokenGeneration, %{}
+    :ok
+  end
+  
+  bench "HS384 token generation" do
+    {:ok, _token} = Joken.Token.encode HS384TokenGeneration, %{}
+    :ok
+  end
+  
+  bench "HS512 token generation" do
+    {:ok, _token} = Joken.Token.encode HS512TokenGeneration, %{}
+    :ok
+  end
+
+  ## ------------------------------
+  ## RS256, RS384, RS512 benchmarks
+  ## ------------------------------
+
+  defmodule RS256TokenGeneration do
+    use BaseConfig, algorithm: :RS256, key: BaseConfig.rsa_key
+  end
+
+  defmodule RS384TokenGeneration do
+    use BaseConfig, algorithm: :RS384, key: BaseConfig.rsa_key
+  end
+
+  defmodule RS512TokenGeneration do
+    use BaseConfig, algorithm: :RS512, key: BaseConfig.rsa_key
+  end
+  
+  bench "RS256 token generation" do
+    {:ok, _token} = Joken.Token.encode RS256TokenGeneration, %{}
+    :ok
+  end
+
+  bench "RS384 token generation" do
+    {:ok, _token} = Joken.Token.encode RS384TokenGeneration, %{}
+    :ok
+  end
+  
+  bench "RS512 token generation" do
+    {:ok, _token} = Joken.Token.encode RS512TokenGeneration, %{}
+    :ok
+  end
+
+  ## ------------------------------
+  ## ES256, ES384, ES512 benchmarks
+  ## ------------------------------
+
+  # This crashes BEAM up. Must review.
+
+  #  defmodule ES256TokenGeneration do
+  #    use BaseConfig, algorithm: :ES256, key: BaseConfig.ec_p256_key
+  #  end
+  #
+  #  defmodule ES384TokenGeneration do
+  #    use BaseConfig, algorithm: :ES384, key: BaseConfig.ec_p384_key
+  #  end
+  #
+  #  defmodule ES512TokenGeneration do
+  #    use BaseConfig, algorithm: :ES512, key: BaseConfig.ec_p521_key
+  #  end
+  #  
+  #  bench "ES256 token generation" do
+  #    {:ok, _token} = Joken.Token.encode ES256TokenGeneration, %{}
+  #    :ok
+  #  end
+  #
+  #  bench "ES384 token generation" do
+  #    {:ok, _token} = Joken.Token.encode ES384TokenGeneration, %{}
+  #    :ok
+  #  end
+  #  
+  #  bench "ES512 token generation" do
+  #    {:ok, _token} = Joken.Token.encode ES512TokenGeneration, %{}
+  #    :ok
+  #  end
+
+  ## ------------------------------
+  ## PS256, PS384, PS512 benchmarks
+  ## ------------------------------
+
+  defmodule PS256TokenGeneration do
+    use BaseConfig, algorithm: :PS256, key: BaseConfig.rsa_key
+  end
+
+  defmodule PS384TokenGeneration do
+    use BaseConfig, algorithm: :PS384, key: BaseConfig.rsa_key
+  end
+
+  defmodule PS512TokenGeneration do
+    use BaseConfig, algorithm: :PS512, key: BaseConfig.rsa_key
+  end
+  
+  bench "PS256 token generation" do
+    {:ok, _token} = Joken.Token.encode PS256TokenGeneration, %{}
+    :ok
+  end
+
+  bench "PS384 token generation" do
+    {:ok, _token} = Joken.Token.encode PS384TokenGeneration, %{}
+    :ok
+  end
+  
+  bench "PS512 token generation" do
+    {:ok, _token} = Joken.Token.encode PS512TokenGeneration, %{}
+    :ok
+  end
+  
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Joken.Mixfile do
       {:earmark, "~> 0.1", only: :docs},
       {:ex_doc, "~> 0.7", only: :docs},
       {:poison, "~> 1.4", only: :test},
-      {:jsx, "~> 2.0", only: :test}
+      {:jsx, "~> 2.0", only: :test},
+      {:benchfella, "~> 0.2", only: :test}      
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
 %{"base64url": {:hex, :base64url, "0.0.1"},
+  "benchfella": {:hex, :benchfella, "0.2.1"},
   "earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.7.3"},
-  "jose": {:hex, :jose, "1.1.0"},
+  "ex_doc": {:hex, :ex_doc, "0.8.0"},
+  "jose": {:hex, :jose, "1.1.1"},
   "jsx": {:hex, :jsx, "2.7.0"},
   "plug": {:hex, :plug, "0.14.0"},
   "poison": {:hex, :poison, "1.4.0"}}


### PR DESCRIPTION
This will eventually close #59 .

This runs a simple benchmark on each of the supported algorithms and provides an easy to spot difference between them. It won't fail the build if there is a regression but will make diagnostics easier anyway. Benchmark output is also appended to the Travis build log. Snapshots (benchfellas output file) are in gitignore. 

**TODO:**
- [ ] Add decoding for all algorithms
- [ ] Add JSX x Poison for tests

This is not yet finished but I needed some help! @potatosalad I am having an `ArgumentError` everytime I try to run benchmarks on ESXXX algorithms. They are commented out now just in case you want to reproduce them. It seems like some ETS issue on jose_jwa. This happens even on 1.1.1. The crash log has:

```shell
23:50:01.199 [error] Process #PID<0.191.0> raised an exception
** (ArgumentError) argument error
    (stdlib) :ets.lookup_element(:jose_jwa, :ec_key_mode, 2)
    src/jose_jwa.erl:89: :jose_jwa.ec_key_mode/0
    src/jose_jwk_kty_ec.erl:47: :jose_jwk_kty_ec.from_map/1
    src/jose_jwk.erl:169: :jose_jwk.from_map/1
    src/jose_jwk.erl:411: :jose_jwk.sign/3
    lib/joken/token.ex:42: Joken.Token.encode/2
    bench/joken_token_bench.exs:159: Joken.Token.Bench."bench: ES256 token generation"/3
    (stdlib) timer.erl:197: :timer.tc/3
```

The output of `:jose_jwa.supports` is:

```elixir
[ciphers: [:aes_cbc128, :aes_cbc192, :aes_cbc256, :aes_ecb128, :aes_ecb192,  :aes_ecb256, :aes_gcm128, :aes_gcm192, :aes_gcm256],
 hashs: [:md5, :sha, :sha256, :sha384, :sha512],
 public_keys: [:ec_gf2m, :ecdh, :ecdsa, :rsa]]
```

And `:crypto.supports` is:

```elixir
[hashs: [:md4, :md5, :sha, :ripemd160, :sha224, :sha256, :sha384, :sha512],
 ciphers: [:des_cbc, :des_cfb, :des3_cbc, :des_ede3, :blowfish_cbc,
  :blowfish_cfb64, :blowfish_ofb64, :blowfish_ecb, :aes_cbc128, :aes_cfb8,
  :aes_cfb128, :aes_cbc256, :rc2_cbc, :aes_ctr, :rc4, :aes_ecb, :des3_cbf,
  :aes_ige256, :aes_gcm],
 public_keys: [:rsa, :dss, :dh, :srp, :ec_gf2m, :ecdsa, :ecdh]]
```