### PR TITLE
Pass skip_verify: true in opts to disable token signature verification.

### DIFF
--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -64,7 +64,8 @@ defmodule Joken.Token do
     
     claims = @claims -- skip_options
 
-    {status, result} = verify_signature(token, get_secret_key(joken_config), joken_config.algorithm)
+    {skip_verify, _} = Dict.pop options, :skip_verify, false
+    {status, result} = verify_signature(token, get_secret_key(joken_config), joken_config.algorithm, skip_verify)
 
     case status do
       :error ->
@@ -96,7 +97,9 @@ defmodule Joken.Token do
 
   end
 
-  defp verify_signature(token, jwk, algorithm) do
+  defp verify_signature(token, _, _, true), do: {:ok, token}
+
+  defp verify_signature(token, jwk, algorithm, _) do
     try do
       case JOSE.JWK.verify(token, jwk) do
         {true, _payload, jws} ->

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -641,6 +641,17 @@ defmodule Joken.Token.Test do
     assert(mesg == "Invalid signature") 
   end
 
+  test "skip signature validation (JSX)" do
+    {:ok, token} = Joken.Token.encode(@jsx_json_module, @payload)
+    assert(token == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.3fazvmF342WiHp5uhY-wkWArn-YJxq1IO7Msrtfk-OQ")
+    {:ok, _} = Joken.Token.decode(@jsx_json_module, token)
+
+    new_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.3fazvmF342WiHp5uhY-wkWArn-YJxq1IO7Msrtfk-OD"
+    {:ok, decoded_payload} = Joken.Token.decode(@jsx_json_module, new_token, skip_verify: true)
+    assert(@payload == decoded_payload)
+
+  end
+
   test "expiration (exp)" do
     defmodule ExpSuccessTest do
       use BaseConfig


### PR DESCRIPTION
This is useful for decoding the contents of a JWT that you don't have the secret key for.