### PR TITLE
Enable crypto_fallback for JOSE algorithms in tests.

### DIFF
--- a/bench/joken_token_bench.exs
+++ b/bench/joken_token_bench.exs
@@ -5,6 +5,7 @@ defmodule Joken.Token.Bench do
   setup_all do
     app = :joken
     :application.ensure_all_started(app)
+    JOSE.JWA.crypto_fallback(true)
     {:ok, app}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Joken.Mixfile do
 
   defp deps do
     [
-      {:jose, "~> 1.1"},
+      {:jose, "~> 1.2"},
       {:plug, "~> 0.14", optional: true},
       {:earmark, "~> 0.1", only: :docs},
       {:ex_doc, "~> 0.7", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"base64url": {:hex, :base64url, "0.0.1"},
   "benchfella": {:hex, :benchfella, "0.2.1"},
   "earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.8.0"},
-  "jose": {:hex, :jose, "1.1.1"},
+  "ex_doc": {:hex, :ex_doc, "0.8.2"},
+  "jose": {:hex, :jose, "1.2.0"},
   "jsx": {:hex, :jsx, "2.7.0"},
   "plug": {:hex, :plug, "0.14.0"},
   "poison": {:hex, :poison, "1.4.0"}}

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -1,6 +1,11 @@
 defmodule Joken.Test do
   use ExUnit.Case
-  
+
+  setup_all do
+    JOSE.JWA.crypto_fallback(true)
+    :ok
+  end
+
   @payload %{ name: "John Doe" }
 
   defmodule BaseConfig do

--- a/test/joken_token_test.exs
+++ b/test/joken_token_test.exs
@@ -1,6 +1,11 @@
 defmodule Joken.Token.Test do
   use ExUnit.Case
 
+  setup_all do
+    JOSE.JWA.crypto_fallback(true)
+    :ok
+  end
+
   @moduledoc """
   Tests calling the Joken.Token module directly
   """

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -2,6 +2,11 @@ defmodule JokenPlug.Test do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  setup_all do
+    JOSE.JWA.crypto_fallback(true)
+    :ok
+  end
+
   defmodule MyConfig do
     @behaviour Joken.Config
 


### PR DESCRIPTION
Updates the jose dependency to 1.2.0 and enables the `crypto_fallback` setting for jose in the tests as mentioned in #62.