### PR TITLE
Added with_* and validate functions

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -136,7 +136,17 @@ defmodule Joken do
     Application.get_env(:joken, :config_module)
   end
 
-
+  @doc """
+  Generates a `Joken.Token` with the following defaults:
+  - Poison as the json_module
+  - claims: exp(now + 2 hours), iat(now), nbf(now - 100ms) and iss ("Joken")
+  - validations for default :
+    - with_validation(:exp, &(&1 > get_current_time))
+    - with_validation(:iat, &(&1 < get_current_time))
+    - with_validation(:nbf, &(&1 < get_current_time))
+    - with_validation(:iss, &(&1 == "Joken"))
+  """
+  @spec token() :: Token.t
   def token() do
     %Token{}
     |> with_json_module(Poison)
@@ -150,87 +160,197 @@ defmodule Joken do
     |> with_validation(:iss, &(&1 == "Joken"))
   end
 
+  @doc """
+  Generates a `Joken.Token` with either a custom payload or a compact token.
+  """
+  @spec token(binary | map) :: Token.t
   def token(payload) when is_map(payload) do
     %Token{claims: payload}
     |> with_json_module(Poison)
   end
-
   def token(token) when is_binary(token) do
     %Token{token: token}
     |> with_json_module(Poison)
   end
 
+  @doc """
+  Configures the default JSON module for Joken.
+  """
+  @spec with_json_module(Token.t, atom) :: Token.t
   def with_json_module(token = %Token{}, module) when is_atom(module) do
     JOSE.json_module(module)
     %{ token | json_module: module }
   end
-  
+
+  @doc """
+  Adds `:exp` claim with a default value of now + 2hs.
+  """
+  @spec with_exp(Token.t) :: Token.t
   def with_exp(token = %Token{claims: claims}) do
     %{ token | claims: Map.put(claims, :exp, get_current_time + (2 * 60 * 60 * 1000)) }
   end
+
+  @doc """
+  Adds `:exp` claim with a given value.
+  """
+  @spec with_exp(Token.t, non_neg_integer) :: Token.t
   def with_exp(token = %Token{claims: claims}, time_to_expire) do
     %{ token | claims: Map.put(claims, :exp, time_to_expire) }
   end
 
+  @doc """
+  Adds `:iat` claim with a default value of now.
+  """
+  @spec with_iat(Token.t) :: Token.t
   def with_iat(token = %Token{claims: claims}) do
     %{ token | claims: Map.put(claims, :iat, get_current_time) }
   end
+  @doc """
+  Adds `:iat` claim with a given value.
+  """
+  @spec with_iat(Token.t, non_neg_integer) :: Token.t
   def with_iat(token = %Token{claims: claims}, time_issued_at) do
     %{ token | claims: Map.put(claims, :iat, time_issued_at) }
   end
 
+  @doc """
+  Adds `:nbf` claim with a default value of now - 100ms.
+  """
+  @spec with_nbf(Token.t) :: Token.t
   def with_nbf(token = %Token{claims: claims}) do
     %{ token | claims: Map.put(claims, :nbf, get_current_time - 100) }
   end
+
+  @doc """
+  Adds `:nbf` claim with a given value.
+  """
+  @spec with_nbf(Token.t, non_neg_integer) :: Token.t
   def with_nbf(token = %Token{claims: claims}, time_not_before) do
     %{ token | claims: Map.put(claims, :nbf, time_not_before) }
   end
 
+  @doc """
+  Adds `:iss` claim with a default value of "Joken".
+  """
+  @spec with_iss(Token.t) :: Token.t
   def with_iss(token = %Token{claims: claims}) do
     %{ token | claims: Map.put(claims, :iss, "Joken") }
   end
+
+  @doc """
+  Adds `:iss` claim with a given value.
+  """
+  @spec with_iss(Token.t, any) :: Token.t
   def with_iss(token = %Token{claims: claims}, issuer) do
     %{ token | claims: Map.put(claims, :iss, issuer) }
   end
 
+  @doc """
+  Adds `:sub` claim with a given value.
+  """
+  @spec with_sub(Token.t, any) :: Token.t
   def with_sub(token = %Token{claims: claims}, sub) do
     %{ token | claims: Map.put(claims, :sub, sub) }
   end
 
+  @doc """
+  Adds `:aud` claim with a given value.
+  """
+  @spec with_aud(Token.t, any) :: Token.t
   def with_aud(token = %Token{claims: claims}, aud) do
     %{ token | claims: Map.put(claims, :aud, aud) }
   end
 
+  @doc """
+  Adds `:jti` claim with a given value.
+  """
+  @spec with_jti(Token.t, any) :: Token.t
   def with_jti(token = %Token{claims: claims}, jti) do
     %{ token | claims: Map.put(claims, :jti, jti) }
   end
 
-  def with_claim(token = %Token{claims: claims}, claim_key, claim_value) do
+  @doc """
+  Adds a custom claim with a given value. The key must be an atom.
+  """
+  @spec with_claim(Token.t, atom, any) :: Token.t
+  def with_claim(token = %Token{claims: claims}, claim_key, claim_value) when is_atom(claim_key) do
     %{ token | claims: Map.put(claims, claim_key, claim_value) }
   end
 
   # convenience functions
+
+  @doc "See Joken.Signer.hs256/1"
   def hs256(secret), do: Signer.hs256(secret)
+
+  @doc "See Joken.Signer.hs384/1"
   def hs384(secret), do: Signer.hs384(secret)
+
+  @doc "See Joken.Signer.hs512/1"
   def hs512(secret), do: Signer.hs512(secret)
 
-  # only adds the signer but does not call sign
+  @doc """
+  Adds a signer to a token configuration. 
+
+  This **DOES NOT** call `sign/1`, `sign/2`, `verify/1` or `verify/2`. 
+  It only sets the signer in the token configuration.
+  """
+  @spec with_signer(Token.t, Signer.t) :: Token.t
   def with_signer(token = %Token{}, signer = %Signer{}) do
     %{ token | signer: signer }
   end
 
+  @doc """
+  Signs a given set of claims. If signing is successful it will put the compact token in 
+  the configuration's token field. Otherwise, it will fill the error field.
+  """
+  @spec sign(Token.t) :: Token.t
   def sign(token), do: Signer.sign(token)
+
+  @doc """
+  Same as `sign/1` but overrides any signer that was set in the configuration.
+  """
+  @spec sign(Token.t, Signer.t) :: Token.t
   def sign(token, signer), do: Signer.sign(token, signer)
 
+  @doc "Convenience function to retrieve the compact token"
+  @spec get_compact(Token.t) :: binary | nil
   def get_compact(%Token{token: token}), do: token
+
+  @doc "Convenience function to retrieve the claim set"
+  @spec get_claims(Token.t) :: map
   def get_claims(%Token{claims: claims}), do: claims 
 
+  @doc """
+  Adds a validation for a given claim key.
+
+  Validation works by applying the given function passing the payload value for that key.
+
+  If it is successful the value is added to the claims. If it fails, then it will raise an
+  ArgumentError.
+
+  If a claim in the payload has no validation, then it **WILL BE ADDED** to the claim set.
+  """
+  @spec with_validation(Token.t, atom, function) :: Token.t
   def with_validation(token = %Token{validations: validations}, claim, function) when is_atom(claim) and is_function(function) do
 
     %{ token | validations: Map.put(validations, claim, function) }
   end
 
+  @doc """
+  Runs verification on the token set in the configuration. 
+  
+  It first checks the signature comparing the header with the one found in the signer.
+
+  Then it runs validations on the decoded payload. If everything passes then the configuration
+  has all the claims available in the claims map.
+  """
+  @spec verify(Token.t) :: Token.t
   def verify(%Token{} = token), do: Signer.verify(token)
+
+  @doc """
+  Same as `verify/1` but overrides any Signer that was present in the configuration.
+  """
+  @spec verify(Token.t, Signer.t) :: Token.t
   def verify(%Token{} = token, %Signer{} = signer), do: Signer.verify(token, signer)
 
 end

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -1,3 +1,86 @@
 defmodule Joken.Signer do
+  alias Joken.Token
+
   defstruct [:jwk, :jws]
+
+  def sign(token = %Token{signer: signer}) when not is_nil(signer) do
+    sign(token, signer)
+  end
+  
+  def sign(token, %Joken.Signer{ jws: nil, jwk: %{ "kty" => "oct" } = jwk }) do
+    jws = %{ "alg" => "HS256" }
+    sign(token, %Joken.Signer{ jwk: jwk, jws: jws})
+  end
+
+  def sign(token, %Joken.Signer{ jws: nil, jwk: jwk }) when is_binary(jwk) do
+    jws = %{ "alg" => "HS256" }
+    sign(token, %Joken.Signer{ jwk: jwk, jws: jws})
+  end
+
+  def sign(token, %Joken.Signer{ jws: jws, jwk: secret }) when is_binary(secret) do
+    jwk = %{ "kty" => "oct", "k" => :base64url.encode(:erlang.iolist_to_binary(secret)) }
+    sign(token, %Joken.Signer{ jwk: jwk, jws: jws})
+  end
+
+  def sign(token, signer) do
+    token = %{ token | signer: signer }
+    {_, compacted_token} = JOSE.JWS.compact(JOSE.JWT.sign(signer.jwk, signer.jws, token.claims))
+    %{ token | token: compacted_token }
+  end
+
+  def verify(token = %Token{signer: signer = %Joken.Signer{}}) do
+    verify(token, signer)
+  end
+
+  def verify(t = %Token{token: token}, %Joken.Signer{jwk: jwk, jws: %{ "alg" => algorithm}}) do
+    try do
+      case JOSE.JWK.verify(token, jwk) do
+        {true, payload, jws} ->
+          jws = :erlang.element(2, JOSE.JWS.to_map(jws))
+          algorithm_string = algorithm |> to_string
+          case jws["alg"] do
+            ^algorithm_string -> 
+              map_payload = decode_payload(t, payload)
+              validate_all_claims(t, map_payload)
+            _ ->
+              %{ t | error: "Invalid signature algorithm" }
+          end
+        _ ->
+          %{ t | error: "Invalid signature" }
+      end
+    catch
+      :error, _ ->
+        %{ t | error: "Missing signature" }
+    end
+  end
+
+  defp decode_payload(%Token{json_module: json}, payload) when is_binary(payload) do
+    json.decode! payload
+  end
+
+  defp validate_all_claims(t = %Token{validations: validations}, map_payload)
+    when is_map(map_payload) do
+
+    try do
+      claims = Enum.map validations, fn(key, value) ->
+
+        case Map.has_key? map_payload, to_string(key) do
+          false ->
+            raise ArgumentError
+          true ->
+            case value.(map_payload[key]) do
+              true ->
+                {key, map_payload[key]}
+              false ->
+                raise ArgumentError 
+            end
+        end
+      end
+      %{ t | claims: Enum.into(claims, %{}) }
+    catch
+      _,_ ->
+        %{ t | error: "Invalid payload" }
+    end
+  end
+  
 end

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -1,45 +1,88 @@
 defmodule Joken.Signer do
   alias Joken.Token
+  alias Joken.Signer
 
   defstruct [:jwk, :jws]
 
-  def sign(token = %Token{signer: signer}) when not is_nil(signer) do
+  @doc "Convenience for generating an HS256 Joken.Signer"
+  def hs256(secret) when is_binary(secret) do
+    %Signer{jws: %{ "alg" => "HS256" },
+            jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
+  end
+
+  @doc "Convenience for generating an HS384 Joken.Signer"
+  def hs384(secret) when is_binary(secret) do
+    %Signer{jws: %{ "alg" => "HS384" },
+            jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
+  end
+
+  @doc "Convenience for generating an HS512 Joken.Signer"
+  def hs512(secret) when is_binary(secret) do
+    %Signer{jws: %{ "alg" => "HS512" },
+            jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
+  end
+
+  @doc """
+  Signs a payload (JOSE header + claims) with the configured signer.
+
+  It raises ArgumentError if no signer was configured.
+  """
+  def sign(%Token{signer: nil}) do
+    raise ArgumentError, message: "Missing Signer"
+  end
+  def sign(token = %Token{signer: signer = %Signer{}}) do
     sign(token, signer)
   end
-  
-  def sign(token, %Joken.Signer{ jws: nil, jwk: %{ "kty" => "oct" } = jwk }) do
-    jws = %{ "alg" => "HS256" }
-    sign(token, %Joken.Signer{ jwk: jwk, jws: jws})
-  end
 
-  def sign(token, %Joken.Signer{ jws: nil, jwk: jwk }) when is_binary(jwk) do
-    jws = %{ "alg" => "HS256" }
-    sign(token, %Joken.Signer{ jwk: jwk, jws: jws})
-  end
+  @doc """
+  Signs a payload (JOSE header + claims) with the given signer.
 
-  def sign(token, %Joken.Signer{ jws: jws, jwk: secret }) when is_binary(secret) do
+  This will override the configured signer.
+  """
+  def sign(token, %Signer{ jws: nil, jwk: %{ "kty" => "oct" } = jwk }) do
+    jws = %{ "alg" => "HS256" }
+    sign(token, %Signer{ jwk: jwk, jws: jws})
+  end
+  def sign(token, %Signer{ jws: nil, jwk: jwk }) when is_binary(jwk) do
+    jws = %{ "alg" => "HS256" }
+    sign(token, %Signer{ jwk: jwk, jws: jws})
+  end
+  def sign(token, %Signer{ jws: jws, jwk: secret }) when is_binary(secret) do
     jwk = %{ "kty" => "oct", "k" => :base64url.encode(:erlang.iolist_to_binary(secret)) }
-    sign(token, %Joken.Signer{ jwk: jwk, jws: jws})
+    sign(token, %Signer{ jwk: jwk, jws: jws})
   end
-
   def sign(token, signer) do
     token = %{ token | signer: signer }
     {_, compacted_token} = JOSE.JWS.compact(JOSE.JWT.sign(signer.jwk, signer.jws, token.claims))
     %{ token | token: compacted_token }
   end
 
-  def verify(token = %Token{signer: signer = %Joken.Signer{}}) do
+  @doc """
+  Verifies a token signature and decodes its payload. This assumes a signer was configured. 
+  It raises if there was none.
+  """
+  def verify(%Token{signer: nil}) do
+    raise ArgumentError, message: "Missing Signer"
+  end
+  def verify(token = %Token{signer: signer = %Signer{}}) do
     verify(token, signer)
   end
 
-  def verify(t = %Token{token: token}, %Joken.Signer{jwk: jwk, jws: %{ "alg" => algorithm}}) do
+  @doc """
+  Verifies a token signature and decodes its payload. 
+  It uses the given signer and sets it on the token.
+  """
+  def verify(t = %Token{token: token}, s = %Signer{jwk: jwk, jws: %{ "alg" => algorithm}}) do
+
+    t = %{ t | signer: s }
+    
     try do
       case JOSE.JWK.verify(token, jwk) do
         {true, payload, jws} ->
           jws = :erlang.element(2, JOSE.JWS.to_map(jws))
           algorithm_string = algorithm |> to_string
           case jws["alg"] do
-            ^algorithm_string -> 
+            ^algorithm_string ->
               map_payload = decode_payload(t, payload)
               validate_all_claims(t, map_payload)
             _ ->
@@ -54,6 +97,7 @@ defmodule Joken.Signer do
     end
   end
 
+  # used to decode payload
   defp decode_payload(%Token{json_module: json}, payload) when is_binary(payload) do
     json.decode! payload
   end
@@ -62,15 +106,14 @@ defmodule Joken.Signer do
     when is_map(map_payload) do
 
     try do
-      claims = Enum.map validations, fn(key, value) ->
-
-        case Map.has_key? map_payload, to_string(key) do
+      claims = Enum.reduce map_payload, [], fn({key, value}, acc) ->
+        case Map.has_key? validations, val_key = String.to_existing_atom(key) do
           false ->
-            raise ArgumentError
+            [{val_key, value} | acc]
           true ->
-            case value.(map_payload[key]) do
+            case validations[val_key].(value) do
               true ->
-                {key, map_payload[key]}
+                [{val_key, value} | acc]
               false ->
                 raise ArgumentError 
             end

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -1,9 +1,14 @@
 defmodule Joken.Token do
-  defstruct json_module: nil, payload: nil, errors: [], token: nil
-
   alias Joken.Utils
 
   @claims [:exp, :nbf, :iat, :aud, :iss, :sub, :jti]
+  
+  defstruct [json_module: Poison,
+             claims: %{},
+             validations: %{},
+             error: nil,
+             token: nil,
+             signer: nil]
 
   @moduledoc """
   Module that handles encoding and decoding of tokens. For most cases, it's recommended to use the Joken module, but

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -3,7 +3,7 @@ defmodule Joken.Token do
 
   @claims [:exp, :nbf, :iat, :aud, :iss, :sub, :jti]
   
-  defstruct [json_module: Poison,
+  defstruct [json_module: nil,
              claims: %{},
              validations: %{},
              error: nil,

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -2,6 +2,22 @@ defmodule Joken.Token do
   alias Joken.Utils
 
   @claims [:exp, :nbf, :iat, :aud, :iss, :sub, :jti]
+
+  @type json_module :: module
+  @type claims      :: %{atom => any}
+  @type validations :: %{atom => function}
+  @type error       :: binary
+  @type token       :: binary
+  @type signer      :: Joken.Signer.t
+
+  @type t :: %__MODULE__{
+    json_module: module,
+    claims: claims,
+    validations: validations,
+    error: error,
+    token: token,
+    signer: signer
+  }
   
   defstruct [json_module: nil,
              claims: %{},

--- a/test/new_joken_test.exs
+++ b/test/new_joken_test.exs
@@ -1,5 +1,5 @@
 defmodule Joken.New.Test do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Joken.Signer
   import Joken
 
@@ -30,6 +30,82 @@ defmodule Joken.New.Test do
     })
 
     assert(signed_token.token == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.xuEv8qrfXu424LZk8bVgr9MQJUIrp1rHcPyZw_KSsds")
+  end
+
+  test "generates default token" do
+
+    token = token()
+
+    assert Map.has_key? token.claims, :exp
+    assert Map.has_key? token.claims, :nbf
+    assert Map.has_key? token.claims, :iat
+    assert Map.has_key? token.claims, :iss
+
+    assert Map.has_key? token.validations, :exp
+    assert Map.has_key? token.validations, :nbf
+    assert Map.has_key? token.validations, :iat
+    assert Map.has_key? token.validations, :iss
+  end
+
+  test "can add custom claim and validation" do
+
+    token = token()
+    |> with_claim(:custom, "custom")
+    |> with_validation(:custom, &(&1 == "custom"))
+
+    assert Map.has_key? token.claims, :custom
+    assert Map.has_key? token.validations, :custom
+  end
+
+  test "signs/verifies token/claims with HS256 convenience" do
+
+    compact = @payload
+    |> token
+    |> sign(hs256("secret"))
+    |> get_compact
+
+    assert compact ==  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.xuEv8qrfXu424LZk8bVgr9MQJUIrp1rHcPyZw_KSsds" 
+
+    claims = compact
+    |> token
+    |> verify(hs256("secret"))
+    |> get_claims
+
+    assert claims == @payload
+  end
+
+  test "signs token with HS384 convenience" do
+
+    compact = @payload
+    |> token
+    |> sign(hs384("test"))
+    |> get_compact
+
+    assert compact == "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.YOH6U5Ggk5_o5B7Dg3pacaKcPkrbFEX-30-trLV6C6wjTHJ_975PXLSEzebOSP8k"
+
+    claims = compact
+    |> token
+    |> verify(hs384("test"))
+    |> get_claims
+
+    assert claims == @payload
+  end
+
+  test "signs token with HS512 convenience" do
+
+    compact = @payload
+    |> token
+    |> sign(hs512("test"))
+    |> get_compact
+
+    assert compact == "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.zi1zohSNwRdHftnWKE16vE3VmbGFtG27LxbYDXAodVlX7T3ATgmJJPjluwf2SPKJND2-O7alOq8NWv6EAnWWyg"
+
+    claims = compact
+    |> token
+    |> verify(hs512("test"))
+    |> get_claims
+
+    assert claims == @payload
   end
 
 end


### PR DESCRIPTION
This is to help on the ongoing effort of refactoring the code base. I know this is incomplete and feel free to deny this PR, but this implements partially (without tests, documentation and type specification) what is being discussed in #62 on top of your initial changes. 

What we have here is:

- all default with_* functions.
- verifying a token
- some refactoring of where the code belongs to (moved signing and verifying to signer)

The intention is to help us move forward in the discussion. With this PR you can do this in iex:

```elixir
import Joken

token 
|> with_sub("I am the subject") 
|> with_validation(:sub, %(&1 == "I am the subject"))
|> with_HS512("my ultra secret secret") # convenience function
|> sign # also convenience. generates the token
|> verify # generates the claims map from a token
```

This still signs/verifies as soon as you call those functions and it returns the struct always. Following some other discussions here I changed errors to error (because the user will not have to pattern match on a list of errors) and assumed some more defaults (mainly Poison). I renamed payload to claims as that is more explicit to me, but feel free to revert that. 

I haven't implemented tests, documentation and specs because I feel like this is a good point to discuss a bit more.