### PR TITLE
Signer plug cleanups

### DIFF
--- a/bench/joken_token_bench.exs
+++ b/bench/joken_token_bench.exs
@@ -76,17 +76,17 @@ defmodule Joken.Token.Bench do
   ## RS256, RS384, RS512 benchmarks
   ## ------------------------------  
   bench "RS256 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "RS256" }, jwk: Keys.rsa_key }) |> get_compact
+    token |> sign(rs256(Keys.rsa_key)) |> get_compact
     :ok
   end
 
   bench "RS384 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "RS384" }, jwk: Keys.rsa_key }) |> get_compact
+    token |> sign(rs384(Keys.rsa_key)) |> get_compact
     :ok
   end
-  
+
   bench "RS512 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "RS512" }, jwk: Keys.rsa_key }) |> get_compact
+    token |> sign(rs512(Keys.rsa_key)) |> get_compact
     :ok
   end
 
@@ -94,17 +94,17 @@ defmodule Joken.Token.Bench do
   ## ES256, ES384, ES512 benchmarks
   ## ------------------------------
   bench "ES256 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "ES256" }, jwk: Keys.ec_p256_key }) |> get_compact
+    token |> sign(es256(Keys.ec_p256_key)) |> get_compact
     :ok
   end
 
   bench "ES384 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "ES384" }, jwk: Keys.ec_p384_key }) |> get_compact
+    token |> sign(es384(Keys.ec_p384_key)) |> get_compact
     :ok
   end
 
   bench "ES512 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "ES512" }, jwk: Keys.ec_p521_key }) |> get_compact
+    token |> sign(es512(Keys.ec_p521_key)) |> get_compact
     :ok
   end
 
@@ -112,17 +112,17 @@ defmodule Joken.Token.Bench do
   ## PS256, PS384, PS512 benchmarks
   ## ------------------------------  
   bench "PS256 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "PS256" }, jwk: Keys.rsa_key }) |> get_compact
+    token |> sign(ps256(Keys.rsa_key)) |> get_compact
     :ok
   end
 
   bench "PS384 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "PS384" }, jwk: Keys.rsa_key }) |> get_compact
+    token |> sign(ps384(Keys.rsa_key)) |> get_compact
     :ok
   end
   
   bench "PS512 token generation" do
-   token |> sign(%Signer{ jws: %{ "alg" => "PS512" }, jwk: Keys.rsa_key }) |> get_compact
+    token |> sign(ps512(Keys.rsa_key)) |> get_compact
     :ok
   end
   

--- a/lib/joken/plug.ex
+++ b/lib/joken/plug.ex
@@ -104,8 +104,8 @@ defmodule Joken.Plug do
   defp parse_auth(conn, ["Bearer " <> incoming_token]) do
     payload_fun = Map.get(conn.private, :joken_on_verifying)
 
-    verified_token = token(incoming_token)
-    |> payload_fun.()
+    verified_token = payload_fun.()
+    |> with_compact_token(incoming_token)
     |> verify
 
     evaluate(conn, verified_token)

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -21,27 +21,35 @@ defmodule Joken.Signer do
   
   defstruct [:jwk, :jws]
 
-  @doc "Convenience for generating an HS256 Joken.Signer"
-  @spec hs256(binary) :: Signer.t
-  def hs256(secret) when is_binary(secret) do
-    %Signer{jws: %{ "alg" => "HS256" },
+  @doc "Convenience for generating an HS*** Joken.Signer"
+  @spec hs(binary, binary) :: Signer.t
+  def hs(alg, secret) when is_binary(secret)
+    and alg in ["HS256", "HS384", "HS512"] do
+    %Signer{jws: %{ "alg" => alg },
             jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
   end
 
-  @doc "Convenience for generating an HS384 Joken.Signer"
-  @spec hs384(binary) :: Signer.t
-  def hs384(secret) when is_binary(secret) do
-    %Signer{jws: %{ "alg" => "HS384" },
-            jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
+  @doc "Convenience for generating an ES*** Joken.Signer"
+  @spec es(binary, map) :: Signer.t
+  def es(alg, key) when is_map(key)
+    and alg in ["ES256", "ES384", "ES512"] do
+    %Signer{jws: %{ "alg" => alg }, jwk: key }
   end
 
-  @doc "Convenience for generating an HS512 Joken.Signer"
-  @spec hs512(binary) :: Signer.t
-  def hs512(secret) when is_binary(secret) do
-    %Signer{jws: %{ "alg" => "HS512" },
-            jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
-  end
+  @doc "Convenience for generating an RS*** Joken.Signer"
+  @spec rs(binary, map) :: Signer.t
+  def rs(alg, key) when is_map(key)
+    and alg in ["RS256", "RS384", "RS512"] do
+    %Signer{jws: %{ "alg" => alg }, jwk: key }
+  end                                             
 
+  @doc "Convenience for generating an PS*** Joken.Signer"
+  @spec ps(binary, map) :: Signer.t
+  def ps(alg, key) when is_map(key)
+    and alg in ["PS256", "PS384", "PS512"] do
+    %Signer{jws: %{ "alg" => alg }, jwk: key }
+  end
+                                               
   @doc """
   Signs a payload (JOSE header + claims) with the configured signer.
 

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -2,6 +2,7 @@ defmodule JokenPlug.Test do
   use ExUnit.Case, async: true
   use Plug.Test
   import Joken
+  alias Joken.Token
 
   setup_all do
     JOSE.JWA.crypto_fallback(true)
@@ -12,12 +13,12 @@ defmodule JokenPlug.Test do
     use Plug.Router
 
     @skip_auth %{joken_skip: true}
-    @is_subject %{joken_on_verifying: &MyPlugRouter.is_subject/1 }
-    @is_not_subject %{joken_on_verifying: &MyPlugRouter.is_not_subject/1 }
+    @is_subject %{joken_on_verifying: &MyPlugRouter.is_subject/0 }
+    @is_not_subject %{joken_on_verifying: &MyPlugRouter.is_not_subject/0 }
 
     plug :match
     plug Joken.Plug,
-      on_verifying: &MyPlugRouter.on_verifying/1,
+      on_verifying: &MyPlugRouter.on_verifying/0,
       on_error: &MyPlugRouter.error_logging/2
     plug :dispatch
 
@@ -62,14 +63,16 @@ defmodule JokenPlug.Test do
       |> send_resp(404, "Not found")
     end
 
-    def is_subject(payload) do
-      payload
+    def is_subject() do
+      %Token{}
+      |> with_json_module(Poison)
       |> with_validation(:sub, &(&1 == 1234567890))
       |> with_signer(hs256("secret"))
     end
 
-    def is_not_subject(payload) do
-      payload
+    def is_not_subject() do
+      %Token{}
+      |> with_json_module(Poison)
       |> with_validation(:sub, &(&1 != 1234567890))
       |> with_signer(hs256("secret"))
     end
@@ -78,8 +81,9 @@ defmodule JokenPlug.Test do
       {conn, message}
     end
 
-    def on_verifying(payload) do
-      payload
+    def on_verifying() do
+      %Token{}
+      |> with_json_module(Poison)
       |> with_signer(hs256("secret"))
       |> with_sub(1234567890)
     end
@@ -108,8 +112,9 @@ defmodule JokenPlug.Test do
       {conn, body}
     end
 
-    def on_verifying(payload) do
-      payload
+    def on_verifying() do
+      %Token{}
+      |> with_json_module(Poison)
       |> with_signer(hs256("secret"))
       |> with_sub(1234567890)
     end


### PR DESCRIPTION
This implements the ideas mentioned in #68. 

- with_compact_token
- removed token in plug's payload_function
- added more convenience functions for signers (and updated benchmark)

I was going to remove all the validate_** from Helper but I think that is better for another PR. 
@bryanjos What do you think?