### PR TITLE
Renamed json_module to serializer

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -9,7 +9,7 @@ defmodule Joken do
 
   All you need to generate a token is a `Joken.Token` struct with proper values. 
   There you can set:
-  - json_module: choose your JSON library (currently supports Poison | JSX)
+  - serializer: choose your JSON library (currently supports Poison | JSX)
   - signer: a map that tells the underlying system how to sign and verify your 
   tokens
   - validations: a map of claims keys to function validations
@@ -23,7 +23,7 @@ defmodule Joken do
 
   @doc """
   Generates a `Joken.Token` with the following defaults:
-  - Poison as the json_module
+  - Poison as the serializer
   - claims: exp(now + 2 hours), iat(now), nbf(now - 100ms) and iss ("Joken")
   - validations for default :
     - with_validation(:exp, &(&1 > get_current_time))
@@ -34,7 +34,7 @@ defmodule Joken do
   @spec token() :: Token.t
   def token() do
     %Token{}
-    |> with_json_module(Poison)
+    |> with_serializer(Poison)
     |> with_exp
     |> with_iat
     |> with_nbf
@@ -47,25 +47,25 @@ defmodule Joken do
 
   @doc """
   Generates a `Joken.Token` with either a custom payload or a compact token. 
-  Defaults Poison as the json module.
+  Defaults Poison as the serializer.
   """
   @spec token(binary | map) :: Token.t
   def token(payload) when is_map(payload) do
     %Token{claims: payload}
-    |> with_json_module(Poison)
+    |> with_serializer(Poison)
   end
   def token(token) when is_binary(token) do
     %Token{token: token}
-    |> with_json_module(Poison)
+    |> with_serializer(Poison)
   end
 
   @doc """
-  Configures the default JSON module for Joken.
+  Configures the default serializer for Joken.
   """
-  @spec with_json_module(Token.t, atom) :: Token.t
-  def with_json_module(token = %Token{}, module) when is_atom(module) do
+  @spec with_serializer(Token.t, atom) :: Token.t
+  def with_serializer(token = %Token{}, module) when is_atom(module) do
     JOSE.json_module(module)
-    %{ token | json_module: module }
+    %{ token | serializer: module }
   end
 
   @doc """

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -134,7 +134,7 @@ defmodule Joken.Signer do
 
   ### PRIVATE
   
-  defp decode_payload(%Token{json_module: json}, payload) when is_binary(payload) do
+  defp decode_payload(%Token{serializer: json}, payload) when is_binary(payload) do
     json.decode! payload
   end
 

--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -1,6 +1,6 @@
 defmodule Joken.Token do
 
-  @type json_module :: module
+  @type serializer :: module
   @type claims      :: %{atom => any}
   @type validations :: %{atom => function}
   @type error       :: binary
@@ -8,7 +8,7 @@ defmodule Joken.Token do
   @type signer      :: Joken.Signer.t
 
   @type t :: %__MODULE__{
-    json_module: module,
+    serializer: module,
     claims: claims,
     validations: validations,
     error: error,
@@ -16,7 +16,7 @@ defmodule Joken.Token do
     signer: signer
   }
   
-  defstruct [json_module: nil,
+  defstruct [serializer: nil,
              claims: %{},
              validations: %{},
              error: nil,

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -65,14 +65,14 @@ defmodule JokenPlug.Test do
 
     def is_subject() do
       %Token{}
-      |> with_json_module(Poison)
+      |> with_serializer(Poison)
       |> with_validation(:sub, &(&1 == 1234567890))
       |> with_signer(hs256("secret"))
     end
 
     def is_not_subject() do
       %Token{}
-      |> with_json_module(Poison)
+      |> with_serializer(Poison)
       |> with_validation(:sub, &(&1 != 1234567890))
       |> with_signer(hs256("secret"))
     end
@@ -83,7 +83,7 @@ defmodule JokenPlug.Test do
 
     def on_verifying() do
       %Token{}
-      |> with_json_module(Poison)
+      |> with_serializer(Poison)
       |> with_signer(hs256("secret"))
       |> with_sub(1234567890)
     end
@@ -114,7 +114,7 @@ defmodule JokenPlug.Test do
 
     def on_verifying() do
       %Token{}
-      |> with_json_module(Poison)
+      |> with_serializer(Poison)
       |> with_signer(hs256("secret"))
       |> with_sub(1234567890)
     end


### PR DESCRIPTION
I had the thought of renaming json_module to serializer. It may not matter much at all, but I think it sounds better. @cs-victor-nascimento what do you think?