### PR TITLE
Added verification options and use only binaries for claims

### DIFF
--- a/test/joken_claims_test.exs
+++ b/test/joken_claims_test.exs
@@ -1,6 +1,5 @@
 defmodule Joken.Claims.Test do
   use ExUnit.Case, async: true
-  import Joken.Fixtures
   import Joken
 
   defmodule FullDerive do
@@ -27,7 +26,7 @@ defmodule Joken.Claims.Test do
 
     token = token
     |> with_claims(%FullDerive{a: 1, b: 2, c: 3})
-    |> with_validation(:a, &(&1 == 1))
+    |> with_validation("a", &(&1 == 1))
 
     assert token.claims == %{a: 1, b: 2, c: 3}
 
@@ -47,7 +46,7 @@ defmodule Joken.Claims.Test do
 
     token = token
     |> with_claims(%OnlyDerive{a: 1, b: 2, c: 3})
-    |> with_validation(:a, &(&1 == 1))
+    |> with_validation("a", &(&1 == 1))
 
     assert token.claims == %{a: 1}
 
@@ -61,15 +60,14 @@ defmodule Joken.Claims.Test do
     |> get_claims
 
     assert test_struct == %OnlyDerive{a: 1}
-    
   end
 
   test "can derive protocol with `exclude` option" do
     
     token = token
     |> with_claims(%ExcludeDerive{a: 1, b: 2, c: 3})
-    |> with_validation(:a, &(&1 == 1))
-    |> with_validation(:c, &(&1 == 3))
+    |> with_validation("a", &(&1 == 1))
+    |> with_validation("c", &(&1 == 3))
 
     assert token.claims == %{a: 1, c: 3}
 

--- a/test/support/keys_fixture.exs
+++ b/test/support/keys_fixture.exs
@@ -8,7 +8,7 @@ defmodule Joken.Fixtures do
   def token_config do
     payload
     |> token
-    |> with_validation(:name, &(&1 == "John Doe"))
+    |> with_validation("name", &(&1 == "John Doe"))
   end
 
   # key taken from Appendix A.2.3 of JWE (Json Web Encryption) RFC


### PR DESCRIPTION
This adds the skip claims option during verifying. I was struggling with the default parameters in Elixir but managed to get it straight without needing to refactor a lot of test code.

Our verify function now accepts 4 parameters: token, signer, module for struct decoding and a list of options. Currently only skip_claims is accepted or checked. I think we should merge the module for decoding into the list of options but that is for another PR/issue. 

So right now we have:

```elixir
some_token
|> verify(hs256("test"), MyStruct, skip_claims: ["name"])
```

Or:

```elixir
some_token
|> verify(hs256("test"), nil, skip_claims: ["name"])
```

If we merge module back to the options list we would have:

```elixir
some_token
|> verify(hs256("test"), [as: MyStruct, skip_claims: ["name"]])
```

Or:

```elixir
some_token
|> verify(hs256("test"), [skip_claims: ["name"]])
```

Besides that, I stumbled upon an issue. The following code:

```elixir
token
|> with_claims(%TestStruct{a: 1, b: 2, c: 3})
|> with_validation(:a, &(&1 == 666))
|> sign(hs256("test"))
|> verify(hs256("test"))
```
Was not producing an error on verification. This is because I used an atom for adding the validation and we were not converting it back to string for indexing the map. This PR forces people to use binaries as keys for claims and validations so that we don't need to worry about that (I guess this is more performatic than makeing the conversion all the time). Sorry about mixing this in this same commit but I got carried away...

I refactored our test code in that matter and everything passes. Also, nothing here seems to impact on performance. 

Should fix #66.