### PR TITLE
Passed struct name to the options list

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -282,22 +282,23 @@ defmodule Joken do
   Then it runs validations on the decoded payload. If everything passes then the configuration
   has all the claims available in the claims map.
 
-  It is possible to pass in a module that will be used to convert the claims back to a struct.
+  It can receive options to verification. Acceptable options are:
 
-  Also, it can receive options to verification such as claims to be skipped.
+  - `skip_claims`: list of claim keys to skip validation
+  - `as`: a module that Joken will use to convert the validated paylod into a sturct
   """
-  @spec verify(Token.t, Signer.t | nil, atom | nil, list) :: Token.t
-  def verify(%Token{} = token, signer \\ nil, module \\ nil, options \\ []),
-    do: Signer.verify(token, signer, module, options)
+  @spec verify(Token.t, Signer.t | nil, list) :: Token.t
+  def verify(%Token{} = token, signer \\ nil, options \\ []),
+    do: Signer.verify(token, signer, options)
   
   @doc """
-  Same as `verify/4` except that it returns either: 
+  Same as `verify/3` except that it returns either: 
   - `{:ok, claims}`
   - `{:error, message}`
   """
-  @spec verify(Token.t, Signer.t | nil, atom | nil, list) :: {:ok, map} | {:error, binary}
-  def verify!(%Token{} = token, signer \\ nil, module \\ nil, options \\ []) do
-    Signer.verify(token, signer, module, options)
+  @spec verify(Token.t, Signer.t | nil, list) :: {:ok, map} | {:error, binary}
+  def verify!(%Token{} = token, signer \\ nil, options \\ []) do
+    Signer.verify(token, signer, options)
     |> do_verify!
   end
 

--- a/test/joken_claims_test.exs
+++ b/test/joken_claims_test.exs
@@ -36,7 +36,7 @@ defmodule Joken.Claims.Test do
 
     test_struct = compact
     |> token
-    |> verify(hs512("test"), FullDerive)
+    |> verify(hs512("test"), as: FullDerive)
     |> get_claims
 
     assert test_struct == %FullDerive{a: 1, b: 2, c: 3}
@@ -56,7 +56,7 @@ defmodule Joken.Claims.Test do
 
     test_struct = compact
     |> token
-    |> verify(hs512("test"), OnlyDerive)
+    |> verify(hs512("test"), as: OnlyDerive)
     |> get_claims
 
     assert test_struct == %OnlyDerive{a: 1}
@@ -77,7 +77,7 @@ defmodule Joken.Claims.Test do
 
     test_struct = compact
     |> token
-    |> verify(hs512("test"), ExcludeDerive)
+    |> verify(hs512("test"), as: ExcludeDerive)
     |> get_claims
 
     assert test_struct == %ExcludeDerive{a: 1, c: 3}

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -129,7 +129,7 @@ defmodule Joken.Test do
     claims = compact
     |> token
     |> with_validation("name", &(&1 == "Must fail if validation is not skipped"))
-    |> verify(hs512("test"), nil, [skip_claims: ["name"]])
+    |> verify(hs512("test"), [skip_claims: ["name"]])
     |> get_claims
 
     assert claims == @payload
@@ -148,7 +148,7 @@ defmodule Joken.Test do
 
     test_struct = compact
     |> token
-    |> verify(hs512("test"), TestStruct)
+    |> verify(hs512("test"), as: TestStruct)
     |> get_claims
 
     assert test_struct == %TestStruct{a: 1, b: 2, c: 3}


### PR DESCRIPTION
As commented on #84 struct name now must be passed with `as:` option.
