### PR TITLE
Enforced binary claims for structs too

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -74,11 +74,12 @@ defmodule Joken do
   end
   
   @doc """
-  Adds `"exp"` claim with a default value of now + 2hs.
+  Adds `"exp"` claim with a default generated value of now + 2hs.
   """
   @spec with_exp(Token.t) :: Token.t
-  def with_exp(token = %Token{claims: claims}) do
-    %{ token | claims: Map.put(claims, "exp", current_time + (2 * 60 * 60 * 1000)) }
+  def with_exp(token = %Token{}) do
+    token
+    |> with_claim_generator("exp", fn -> current_time + (2 * 60 * 60 * 1000) end)
   end
 
   @doc """
@@ -90,11 +91,12 @@ defmodule Joken do
   end
 
   @doc """
-  Adds `"iat"` claim with a default value of now.
+  Adds `"iat"` claim with a default generated value of now.
   """
   @spec with_iat(Token.t) :: Token.t
-  def with_iat(token = %Token{claims: claims}) do
-    %{ token | claims: Map.put(claims, "iat", current_time) }
+  def with_iat(token = %Token{}) do
+    token
+    |> with_claim_generator("iat", fn -> current_time end)
   end
   @doc """
   Adds `"iat"` claim with a given value.
@@ -105,11 +107,12 @@ defmodule Joken do
   end
 
   @doc """
-  Adds `"nbf"` claim with a default value of now - 100ms.
+  Adds `"nbf"` claim with a default generated value of now - 100ms.
   """
   @spec with_nbf(Token.t) :: Token.t
-  def with_nbf(token = %Token{claims: claims}) do
-    %{ token | claims: Map.put(claims, "nbf", current_time - 100) }
+  def with_nbf(token = %Token{}) do
+    token
+    |> with_claim_generator("nbf", fn -> current_time - 100 end)
   end
 
   @doc """

--- a/lib/joken/claims.ex
+++ b/lib/joken/claims.ex
@@ -31,7 +31,16 @@ defimpl Joken.Claims, for: Map do
   end
 
   def to_claims(data) do
-    data
+    Enum.reduce data, %{}, fn({key, value}, acc) ->
+      case key do
+        key when is_atom(key) ->
+          Map.put(acc, Atom.to_string(key), value)
+        key when is_binary(key) ->
+          Map.put(acc, key, value)
+        _ ->
+          raise "Claim keys must be binaries"
+      end
+    end
   end
 end
 

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -142,6 +142,8 @@ defmodule Joken.Signer do
     end
   end
   
+  defp decode_payload(%Token{json_module: nil}, _),
+    do: raise(ArgumentError, message: "No JSON module defined")
   defp decode_payload(%Token{json_module: json}, payload) when is_binary(payload) do
     json.decode! payload
   end
@@ -168,11 +170,12 @@ defmodule Joken.Signer do
         end
       end
 
-      claims = Enum.into(claims, %{})
       if struct_name = options[:as] do
         claims = struct(struct_name, Enum.map(claims, fn({key, value}) ->
           { String.to_existing_atom(key), value }
         end))
+      else
+        claims = Enum.into(claims, %{})
       end
 
       %{ t | claims: claims }

--- a/test/joken_claims_test.exs
+++ b/test/joken_claims_test.exs
@@ -24,11 +24,12 @@ defmodule Joken.Claims.Test do
   
   test "can derive protocol implementation" do
 
-    token = token
+    token = %Joken.Token{}
+    |> with_json_module(Poison)
     |> with_claims(%FullDerive{a: 1, b: 2, c: 3})
     |> with_validation("a", &(&1 == 1))
 
-    assert token.claims == %{a: 1, b: 2, c: 3}
+    assert token.claims == %{"a" => 1, "b" => 2, "c" => 3}
 
     compact = token
     |> sign(hs512("test"))
@@ -44,11 +45,12 @@ defmodule Joken.Claims.Test do
 
   test "can derive protocol with `only` option" do
 
-    token = token
+    token = %Joken.Token{}
+    |> with_json_module(Poison)
     |> with_claims(%OnlyDerive{a: 1, b: 2, c: 3})
     |> with_validation("a", &(&1 == 1))
 
-    assert token.claims == %{a: 1}
+    assert token.claims == %{"a" => 1}
 
     compact = token
     |> sign(hs512("test"))
@@ -64,12 +66,13 @@ defmodule Joken.Claims.Test do
 
   test "can derive protocol with `exclude` option" do
     
-    token = token
+    token = %Joken.Token{}
+    |> with_json_module(Poison)
     |> with_claims(%ExcludeDerive{a: 1, b: 2, c: 3})
     |> with_validation("a", &(&1 == 1))
     |> with_validation("c", &(&1 == 3))
 
-    assert token.claims == %{a: 1, c: 3}
+    assert token.claims == %{"a" => 1, "c" => 3}
 
     compact = token
     |> sign(hs512("test"))

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -47,9 +47,9 @@ defmodule Joken.Test do
 
     token = token()
 
-    assert Map.has_key? token.claims, "exp"
-    assert Map.has_key? token.claims, "nbf"
-    assert Map.has_key? token.claims, "iat"
+    assert Map.has_key? token.claims_generation, "exp"
+    assert Map.has_key? token.claims_generation, "nbf"
+    assert Map.has_key? token.claims_generation, "iat"
 
     assert Map.has_key? token.validations, "exp"
     assert Map.has_key? token.validations, "nbf"
@@ -136,7 +136,7 @@ defmodule Joken.Test do
   end
   
   test "using a struct for claims" do
-    token = token()
+    token = %Joken.Token{}
     |> with_claims(%TestStruct{a: 1, b: 2, c: 3})
     |> with_validation("a", &(&1 == 1))
 
@@ -227,7 +227,8 @@ defmodule Joken.Test do
 
   test "can remove validations" do
 
-    token = token()
+    token = %Joken.Token{}
+    |> with_json_module(Poison)
     |> with_claims(%TestStruct{a: 2, b: 2, c: 3})
     |> with_validation("a", &(&1 == 1))
     |> sign(hs256("test"))
@@ -241,7 +242,7 @@ defmodule Joken.Test do
 
     assert token.error == nil
   end
-  
+
   # utility functions
   defp assert_invalid_rsa_signature(compact_token, signer) do
 


### PR DESCRIPTION
This has no issue associated but I was investigating if we need any more fixes before 0.16.0 and this came up. Look the above code:

```elixir
defmodule TestStruct do
  defstruct a: nil, b: nil
end

token = %Joken.Token{}
|> with_json_module(Poison)
|> with_claims(%TestStruct{a: 1, b: 2})
```

This would produce a Joken.Token with `claims: %{a: 1, b: 2}` instead of `claims: %{"a" => 1, "b" => 2}`. Since we opted to go all binary, this PR ensure that using `with_claims` will produce binary keys for claims.

Also, again, in the same commit, I changed the default `with_exp`, `with_iat`, `with_nbf` to use generators instead of fixed values. I know this should have gone in a separate PR but one thing led to the other...

As I said I am investigating if we need any more patches to make everything align for 0.16.0. Expect more PRs like this \o/