### PR TITLE
Updated the version number to allow it to work with elixir 1.1-beta

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Joken.Mixfile do
   def project do
     [app: :joken,
      version: "0.16.0-dev",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      description: description,
      package: package,
      deps: deps]


### PR DESCRIPTION
I tried out the 1.1 beta and noticed that the elixir version in mix.exs was too restrictive to allow it to work. this makes it so it can run on both elixir 1.0 and 1.1.