### PR TITLE
Makes travis-ci badge to point to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Joken [![Documentation](https://img.shields.io/badge/docs-hexpm-blue.svg)](http://hexdocs.pm/joken/) [![Downloads](https://img.shields.io/hexpm/dt/joken.svg)](https://hex.pm/packages/joken) [![Build](https://travis-ci.org/bryanjos/joken.svg)](https://travis-ci.org/bryanjos/joken.svg)
+# Joken [![Documentation](https://img.shields.io/badge/docs-hexpm-blue.svg)](http://hexdocs.pm/joken/) [![Downloads](https://img.shields.io/hexpm/dt/joken.svg)](https://hex.pm/packages/joken) [![Build](https://travis-ci.org/bryanjos/joken.svg?branch=master)](https://travis-ci.org/bryanjos/joken)
 
 [Documentation](http://hexdocs.pm/joken/)
 


### PR DESCRIPTION
Makes Travis-ci not to use the last build
but the last build in master for the badge