### PR TITLE
Use `verify_strict/3` from jose instead of `verify/2`. See #110

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Joken.Mixfile do
 
   defp deps do
     [
-      {:jose, "~> 1.3"},
+      {:jose, "~> 1.4"},
       {:plug, "~> 1.0", optional: true},
       {:poison, "~> 1.5", optional: true},
       {:earmark, "~> 0.1", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"base64url": {:hex, :base64url, "0.0.1"},
   "benchfella": {:hex, :benchfella, "0.2.1"},
-  "earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "jose": {:hex, :jose, "1.3.0"},
-  "jsx": {:hex, :jsx, "2.7.1"},
-  "plug": {:hex, :plug, "1.0.0"},
+  "earmark": {:hex, :earmark, "0.1.19"},
+  "ex_doc": {:hex, :ex_doc, "0.11.0"},
+  "jose": {:hex, :jose, "1.4.1"},
+  "jsx": {:hex, :jsx, "2.8.0"},
+  "plug": {:hex, :plug, "1.0.2"},
   "poison": {:hex, :poison, "1.5.0"}}


### PR DESCRIPTION
The [`JOSE.JWS.verify_strict/3`](https://hexdocs.pm/jose/JOSE.JWS.html#verify_strict/3) function allows you to whitelist which signature algorithms can be verified prior to fully decoding the jws header.