### PR TITLE
Add EdDSA support: Ed25519, Ed25519ph, Ed448, Ed448ph

### DIFF
--- a/bench/joken_token_bench.exs
+++ b/bench/joken_token_bench.exs
@@ -92,5 +92,28 @@ defmodule Joken.Token.Bench do
     token |> sign(ps512(rsa_key)) |> get_compact
     :ok
   end
+
+  ## ---------------------------------------------
+  ## Ed25519, Ed25519ph, Ed448, Ed448ph benchmarks
+  ## ---------------------------------------------
+  bench "Ed25519 token generation" do
+    token |> sign(ed25519(ed25519_key)) |> get_compact
+    :ok
+  end
+
+  bench "Ed25519ph token generation" do
+    token |> sign(ed25519ph(ed25519ph_key)) |> get_compact
+    :ok
+  end
+
+  bench "Ed448 token generation" do
+    token |> sign(ed448(ed448_key)) |> get_compact
+    :ok
+  end
+
+  bench "Ed448ph token generation" do
+    token |> sign(ed448ph(ed448ph_key)) |> get_compact
+    :ok
+  end
   
 end

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -215,6 +215,19 @@ defmodule Joken do
   @doc "See Joken.Signer.hs/2"
   def hs512(secret), do: Signer.hs("HS512", secret)
 
+  # EdDSA
+  @doc "See Joken.Signer.eddsa/2"
+  def ed25519(key), do: Signer.eddsa("Ed25519", key)
+
+  @doc "See Joken.Signer.eddsa/2"
+  def ed25519ph(key), do: Signer.eddsa("Ed25519ph", key)
+
+  @doc "See Joken.Signer.eddsa/2"
+  def ed448(key), do: Signer.eddsa("Ed448", key)
+
+  @doc "See Joken.Signer.eddsa/2"
+  def ed448ph(key), do: Signer.eddsa("Ed448ph", key)
+
   #
   @doc "See Joken.Signer.es/2"
   def es256(key), do: Signer.es("ES256", key)

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -57,6 +57,13 @@ defmodule Joken.Signer do
             jwk: %{ "kty" => "oct", "k" => :base64url.encode(secret) }}
   end
 
+  @doc "Convenience for generating an EdDSA Joken.Signer"
+  @spec eddsa(binary, map) :: Signer.t
+  def eddsa(alg, key) when is_map(key)
+    and alg in ["Ed25519", "Ed25519ph", "Ed448", "Ed448ph"] do
+    %Signer{jws: %{ "alg" => alg }, jwk: key }
+  end
+
   @doc "Convenience for generating an ES*** Joken.Signer"
   @spec es(binary, map) :: Signer.t
   def es(alg, key) when is_map(key)

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Joken.Mixfile do
 
   defp deps do
     [
-      {:jose, "~> 1.4"},
+      {:jose, "~> 1.6"},
       {:plug, "~> 1.0", optional: true},
       {:poison, "~> 1.5", optional: true},
       {:earmark, "~> 0.1", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"base64url": {:hex, :base64url, "0.0.1"},
-  "benchfella": {:hex, :benchfella, "0.2.1"},
-  "earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.11.0"},
-  "jose": {:hex, :jose, "1.4.1"},
+  "benchfella": {:hex, :benchfella, "0.3.1"},
+  "earmark": {:hex, :earmark, "0.2.1"},
+  "ex_doc": {:hex, :ex_doc, "0.11.3"},
+  "jose": {:hex, :jose, "1.6.0"},
   "jsx": {:hex, :jsx, "2.8.0"},
-  "plug": {:hex, :plug, "1.0.2"},
-  "poison": {:hex, :poison, "1.5.0"}}
+  "plug": {:hex, :plug, "1.1.0"},
+  "poison": {:hex, :poison, "1.5.2"}}

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -178,6 +178,15 @@ defmodule Joken.Test do
     assert error == "Invalid signature"
   end
 
+  test "signs/verifies token with EdDSA" do
+
+    verify_for_dynamic_token(ed25519_token, ed25519(ed25519_key))
+    verify_for_dynamic_token(ed25519ph_token, ed25519ph(ed25519ph_key))
+    verify_for_dynamic_token(ed448_token, ed448(ed448_key))
+    verify_for_dynamic_token(ed448ph_token, ed448ph(ed448ph_key))
+
+  end
+
   test "signs/verifies token with ES***" do
 
     verify_for_dynamic_token(es256_token, es256(ec_p256_key))

--- a/test/support/keys_fixture.exs
+++ b/test/support/keys_fixture.exs
@@ -60,6 +60,50 @@ defmodule Joken.Fixtures do
       "y" => "AH0EUWVaoVROX3_OzzQIZLuKG5546exe5-0cQ-E7thMaH6-k5cqcyIedCuX1c9lOWcXgo2NLlj4JOwSetCpOspEM"}
   end
 
+  def ed25519_key do
+    %{"crv" => "Ed25519",
+      "d" => "VoU6Pm8SOjz8ummuRPsvoJQOPI3cjsdMfUhf2AAEc7s",
+      "kty" => "OKP",
+      "x" => "l11mBSuP-XxI0KoSG7YEWRp4GWm7dKMOPkItJy2tlMM"}
+  end
+
+  def ed25519ph_key do
+    %{"crv" => "Ed25519ph",
+      "d" => "D8PU55JCryvSLK44AaCcAYj99P2MDQdxmNJhTUhFqTA",
+      "kty" => "OKP",
+      "x" => "JnLdiNg-GBTQjukBZUPinl56Au_kF58adtqtzrXnZTs"}
+  end
+
+  def ed448_key do
+    %{"crv" => "Ed448",
+      "d" => "-ox5cBHY-QLR0hRdE2gd97LkQ8oRZCT89ALXm-FqhINLdVEd_PtfHuetZoKeHALqwu-NfuADYDBL",
+      "kty" => "OKP",
+      "x" => "BnJNZy1_JXpGRlrNLYsz_9I5NCM-Py39P1kEOyrLRXJj38rnOJe7cJaVsOnPj2NkL_jVtG_qkjOA"}
+  end
+
+  def ed448ph_key do
+    %{"crv" => "Ed448ph",
+      "d" => "1AlVWjtG0cTvUSQrqgXHqYTBP07FljGGvO5SZhAgtt92NTBcuTs_HedSqvikyHhhcsE4PsTHXBx0",
+      "kty" => "OKP",
+      "x" => "pqCS-juwmDl_-uZhliMmaZNssMukorRdQcqC8Nu44uYyBDgpkc_i-Ir1rYjPzLOlNHEGyb0dIN-A"}
+  end
+
+  def ed25519_token do
+    "eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJuYW1lIjoiSm9obiBEb2UifQ.9a7z_qCuHwBMVSOG9sDzc2Ccbk49tY2GLddqViz0nuB4zG9pQS-jhhGpkYwQ9LE33742__nujzWLaSJ93tYhAw"
+  end
+
+  def ed25519ph_token do
+    "eyJhbGciOiJFZDI1NTE5cGgiLCJ0eXAiOiJKV1QifQ.eyJuYW1lIjoiSm9obiBEb2UifQ.VRTZ7LyOmmPTn382rK6vP4VMYYBiQGz6i-Hpf8IB5flmcBavDmLqed8Q-h9uRlSRCTkemIBDpqKE-7zj9RlgBw"
+  end
+
+  def ed448_token do
+    "eyJhbGciOiJFZDQ0OCIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.8eVjWUndsxWOzJMRQn5BqFJDMrcIj950zmKdSkXH2NBSCRETJD0YFA3HocSiWOgswHKZXIcYeT0AFc1JjH3LGl_oREiotTuU20b8USt3Z81VzqmMG2fvx5QlwKlZwwk4A2V5F2X-d1Ky0z1VV1PovjcA"
+  end
+
+  def ed448ph_token do
+    "eyJhbGciOiJFZDQ0OHBoIiwidHlwIjoiSldUIn0.eyJuYW1lIjoiSm9obiBEb2UifQ.T4PiW8b_l0XqEI3NLXHFvHUifD0SpNNLpMwLbT-QuLE03FZ105Voyeh7uB87WxbSwWuZOyZfPQ6Az4N41A2oRsoTS7v9jeqizIP240vve3VB7sLs6zl9Vgb4nH6k0jvQUMKPBw7Mf6KbPN1a_rumIj0A"
+  end
+
   def es256_token do
     "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.ozw2CHDqSE1t5CXXP50x52tr07Nj7HGSBWGytDj93gcHxS65TJ6Tv0RrOei-WtauDN3beXF5e7lZ8c5MPwx0-w"
   end


### PR DESCRIPTION
This pull request updates [jose](https://github.com/potatosalad/erlang-jose) to version 1.6.0 with support added for JSON Web Keys with a `"kty"` of `"OKP"` and `"crv"` of `"Ed25519"`, `"Ed25519ph"`, `"Ed448"`, and `"Ed448ph"`.

##### Short Explanation

The signature algorithms based on the edwards25519 and edwards448 curves are part of a [draft](https://tools.ietf.org/html/draft-ietf-jose-cfrg-curves) published by the JOSE working group.  Due to community concern over NSA involvement with NIST, if you are currently using the `ES256` or `ES384` signature algorithms, the `Ed25519` or `Ed448` signature algorithms may offer safer alternative algorithms.

The `ph` suffix stands for "prehash" which just means that the message to be signed gets passed through a preset hashing algorithm before signing and verifying.

##### Long Explanation

Since @bryanjos thanked me for one of my previous explanations, I'm writing another one that's hopefully an interesting read about these new signature algorithms.  You can also just skip down to "Implementation Details" below :grinning:  Here's some history that I'll do my best to explain briefly and correctly:

The [National Institute of Standards and Technology (NIST)](http://www.nist.gov/) previously proposed two elliptic curve standards, `NIST P-256` and `NIST P-384`, which are used by `ES256` and `ES384`, respectively.  However, due to [various controversies](https://en.wikipedia.org/wiki/National_Institute_of_Standards_and_Technology#Controversy), weaknesses discovered, and general community concern about NIST's involvement with the NSA, the `NIST P-256` and `NIST P-384` curves are no longer considered safe by [safecurves.cr.yp.to](https://safecurves.cr.yp.to/).

Quoting from [draft-irtf-cfrg-curves](https://tools.ietf.org/html/draft-irtf-cfrg-curves):

> There is...concern in the community regarding the generation and potential weaknesses of the curves defined by NIST.

The last curve defined in the original [JWA RFC 7518](https://tools.ietf.org/html/rfc7518#section-3.1) is `E-521` which is used by `ES512` and is still considered safe.  The three main proponents for `E-521` were [Daniel J. Bernstein](http://cr.yp.to/djb.html), [Tanja Lange](http://hyperelliptic.org/tanja/), and [Mike Hamburg](https://shiftleft.org/papers/).

Later, Bernstein published a paper detailing [Curve25519](http://cr.yp.to/ecdh/curve25519-20060209.pdf) which is a [Montgomery curve](https://en.wikipedia.org/wiki/Montgomery_curve).  Bernstein, Tanja, and others later published a paper entitled ["High-speed high-security signatures"](http://ed25519.cr.yp.to/ed25519-20110926.pdf) which detailed the Ed25519 algorithm which used an [Edwards curve](https://en.wikipedia.org/wiki/Edwards_curve) and a [Twisted Edwards curve](https://en.wikipedia.org/wiki/Twisted_Edwards_curve) for faster modular arithmetic.  Curve25519 and Ed25519 offer ~128 bits of security.

Even more recently, Mike Hamburg published a paper detailing [Ed448-Goldilocks](https://shiftleft.org/papers/goldilocks/goldilocks.pdf) which is also based around Montgomery, Edwards, and Twisted Edwards curves much like Curve25519 and Ed25519.  It was designed to provide a "just right" level of high-security in between 384 and 521 bits of security (Curve448 and Ed448 offer ~448 bits of security).

Long story short, the crypto community is wary to trust the curves recommended by NIST due to their involvement with the NSA, so many are moving to the independently researched curve25519 and curve448.  As an example of this, Google recently added curve25519 support to their [boringssl](https://boringssl.googlesource.com/boringssl/+/master/crypto/curve25519/) library which is used by Chrome, Android, and other projects.

Here are the current draft references from the [jose working group](https://datatracker.ietf.org/wg/jose/documents/) and [cfrg research group](https://datatracker.ietf.org/rg/cfrg/documents/):

 * CFRG ECDH and signatures in JOSE [draft-ietf-jose-cfrg-curves](https://tools.ietf.org/html/draft-ietf-jose-cfrg-curves)
 * Elliptic Curves for Security [draft-irtf-cfrg-curves](https://tools.ietf.org/html/draft-irtf-cfrg-curves)
 * Edwards-curve Digital Signature Algorithm (EdDSA) [draft-irtf-cfrg-eddsa](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa)

##### Implementation Details

By default, `Ed25519`, `Ed25519ph`, `Ed448`, and `Ed448ph` are disabled because they are not supported by the native Erlang `crypto` module.  By enabling the pure Erlang implementations of the algorithms using [`JOSE.crypto_fallback(true)`](https://hexdocs.pm/jose/JOSE.html#crypto_fallback/1), all 4 algorithms are available for use.  They are, however, fairly slow:

```
HS256 token generation           10000   106.83 µs/op
HS384 token generation           10000   111.67 µs/op
HS512 token generation           10000   119.73 µs/op
ES256 token generation            2000   922.35 µs/op
ES384 token generation            1000   1547.44 µs/op
RS256 token generation            1000   1695.90 µs/op
RS384 token generation            1000   1708.17 µs/op
RS512 token generation            1000   1717.87 µs/op
ES512 token generation             500   3012.72 µs/op
PS512 token generation             500   3301.96 µs/op
PS384 token generation             500   3332.74 µs/op
PS256 token generation             500   3547.75 µs/op
Ed25519 token generation           500   4414.28 µs/op
Ed25519ph token generation         500   4541.71 µs/op
Ed448ph token generation           100   10566.50 µs/op
Ed448 token generation             100   11622.64 µs/op
```

Native C support for `Ed25519` and `Ed25519ph` can be provided by the [libsodium](https://github.com/potatosalad/erlang-libsodium) asynchronous port driver by adding it as a dependency to a project's Mix file:

```elixir
defp deps do
  [
    {:joken, "~> 1.0.0"},
    {:libsodium, "~> 0.0.2"}
  ]
end
```

While there isn't native C support for `Ed448` and `Ed448ph` yet, there *is* a notable performance improvement by using a native C driver the SHA-3 related functions used by these signature algorithms by adding the [keccakf1600](https://github.com/potatosalad/erlang-keccakf1600) asynchronous port driver as a dependency to a project's Mix file:

```elixir
defp deps do
  [
    {:joken, "~> 1.0.0"},
    {:keccakf1600, "~> 0.0.1"}
  ]
end
```

The effects of these two external libraries can be seen in the benchmark numbers and the graph comparing the algorithms with and without libsodium and keccakf1600:

```
HS256 token generation           20000   81.49 µs/op
HS512 token generation           20000   83.46 µs/op
HS384 token generation           20000   84.17 µs/op
Ed25519 token generation         10000   256.94 µs/op
Ed25519ph token generation       10000   264.41 µs/op
ES256 token generation            2000   909.40 µs/op
ES384 token generation            1000   1699.80 µs/op
RS384 token generation            1000   1702.05 µs/op
RS512 token generation            1000   1763.16 µs/op
RS256 token generation            1000   1814.06 µs/op
ES512 token generation             500   3333.85 µs/op
PS512 token generation             500   3609.30 µs/op
PS384 token generation             500   3695.40 µs/op
PS256 token generation             500   3736.64 µs/op
Ed448ph token generation           500   6411.58 µs/op
Ed448 token generation             500   6738.13 µs/op
```

![Ed25519, Ed25519ph, Ed448, Ed44ph with and without libsodium and keccakf1600 graph](https://cloud.githubusercontent.com/assets/1804/12488151/7330971e-c027-11e5-8815-94c3371288bf.png)

The interesting part of the graph is that `Ed25519` and `Ed25519ph` algorithms are almost as fast as the symmetric key based HMAC algorithms `HS256`, `HS384`, and `HS512`.  However, they offer everything that the `ES256`, `ES384`, and `ES512` algorithms provide as asymmetric key based algorithms: public/private keys, signing/verifying, and key exchange for encryption through [`X25519` with `ECDH-ES`](https://hexdocs.pm/jose/JOSE.JWE.html).  Once there is a native C implementation of `Ed448` and `Ed448ph`, similar performance for those algorithms could also be possible.

Key generation can be accomplished with [`JOSE.JWK.generate_key/1`](https://hexdocs.pm/jose/JOSE.JWK.html#generate_key/1):

```elixir
jwk_Ed25519   = JOSE.JWK.generate_key({:okp, :Ed25519})
jwk_Ed25519ph = JOSE.JWK.generate_key({:okp, :Ed25519ph})
jwk_Ed448     = JOSE.JWK.generate_key({:okp, :Ed448})
jwk_Ed448ph   = JOSE.JWK.generate_key({:okp, :Ed448ph})
```

For more information about generating EdDSA keypairs (for example, with `ssh-keygen`), checkout the [OKP key generation](https://hexdocs.pm/jose/extra-key-generation.html#OKP) and [`JOSE.JWS`](https://hexdocs.pm/jose/JOSE.JWS.html) documentation.