### PR TITLE
Make generated claims available after signing

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -269,8 +269,9 @@ defmodule Joken do
     do: %{ token | signer: signer }
 
   @doc """
-  Signs a given set of claims. If signing is successful it will put the compact token in
-  the configuration's token field. Otherwise, it will fill the error field.
+  Signs a given set of claims. If signing is successful it will put the compact
+  token in the configuration's token field and move generated claims into the
+  claims set. Otherwise, it will fill the error field.
   """
   @spec sign(Token.t) :: Token.t
   def sign(token), do: Signer.sign(token)
@@ -285,7 +286,10 @@ defmodule Joken do
   @spec get_compact(Token.t) :: binary | nil
   def get_compact(%Token{token: token}), do: token
 
-  @doc "Convenience function to retrieve the claim set"
+  @doc """
+  Convenience function to retrieve the claim set. Generated claims will only
+  become available after signing the token.
+  """
   @spec get_claims(Token.t) :: map
   def get_claims(%Token{claims: claims}), do: claims
 

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -126,7 +126,7 @@ defmodule Joken.Signer do
     claims = prepare_claims(token)
 
     {_, compacted_token} = JOSE.JWS.compact(JOSE.JWT.sign(signer.jwk, signer.jws, claims))
-    %{ token | token: compacted_token }
+    %{ token | token: compacted_token, claims: claims, claims_generation: %{} }
   end
 
   @doc """

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -67,6 +67,22 @@ defmodule Joken.Test do
     assert Map.has_key? token.validations, "custom"
   end
 
+  test "generated claims become static after signing" do
+    token = token()
+    |> with_claim("static", "static")
+    |> with_claim_generator("dynamic", fn -> "dynamic" end)
+
+    assert Map.has_key? token.claims, "static"
+    assert Map.has_key? token.claims_generation, "dynamic"
+
+    signed = sign(token, hs256("secret"))
+
+    assert Map.has_key? signed.claims, "static"
+    assert Map.has_key? signed.claims, "dynamic"
+
+    assert signed.claims_generation == %{}
+  end
+
   test "signs/verifies token/claims with HS256 convenience" do
 
     compact = @payload


### PR DESCRIPTION
Currently it’s a bit tricky to retrieve generated claims after signing a token since the `claims` fields only includes those that are not generated.

This proposed solution changes `Signer.sign/2` to move any generated claims into `claims` and clear out the `claims_generation` map after signing. This way it’s easy to just use `Joken.get_claims/1` to fetch the claims that were signed.

Please let me know if you have any suggestions related to this. Thanks!