### PR TITLE
Allow current timestamp with default iat validator

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -27,7 +27,7 @@ defmodule Joken do
   - claims: exp(now + 2 hours), iat(now), nbf(now - 100ms) and iss ("Joken")
   - validations for default :
     - with_validation("exp", &(&1 > current_time))
-    - with_validation("iat", &(&1 < current_time))
+    - with_validation("iat", &(&1 <= current_time))
     - with_validation("nbf", &(&1 < current_time))
   """
   @spec token() :: Token.t
@@ -38,7 +38,7 @@ defmodule Joken do
     |> with_iat
     |> with_nbf
     |> with_validation("exp", &(&1 > current_time))
-    |> with_validation("iat", &(&1 < current_time))
+    |> with_validation("iat", &(&1 <= current_time))
     |> with_validation("nbf", &(&1 < current_time))
   end
 

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -66,6 +66,18 @@ defmodule Joken.Test do
       |> verify!(signer)
   end
 
+  test "ensure iat validation passes for same second" do
+
+      now = current_time()
+
+      assert {:ok, _} = @payload
+      |> token
+      |> with_iat(now)
+      |> with_validation("iat", &(&1 <= now))
+      |> sign(hs256("secret"))
+      |> verify!
+  end
+
   test "can add custom claim and validation" do
 
     token = token()

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -57,6 +57,15 @@ defmodule Joken.Test do
     assert Map.has_key? token.validations, "iat"
   end
 
+  test "default validations pass" do
+    signer = hs256("secret")
+
+    assert {:ok, _} =
+      token()
+      |> sign(signer)
+      |> verify!(signer)
+  end
+
   test "can add custom claim and validation" do
 
     token = token()


### PR DESCRIPTION
The `iat` claim was being validated by comparing it with the current timestamp
without allowing equality, which made validation fail when it was performed
within a second of signing the token.