### PR TITLE
Removing on_load callback from Joken.Signer

### DIFF
--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -3,8 +3,6 @@ defmodule Joken.Signer do
   alias Joken.Signer
   require Logger
 
-  @on_load :configure_unsecured_signing
-
   @moduledoc """
   Signer is the JWK (JSON Web Key) and JWS (JSON Web Signature) configuration of Joken.
 


### PR DESCRIPTION
- This causes applications built with exrm to fail. When erlang is
  running in embedded mode, all modules are loaded first, and then
  applications are started. Inside JOSE, the call to
  JOSE.unsecured_signing tries to do a gen_server:call to a process
  that hasn't started yet, and the whole thing hangs waiting for the
  call to complete.

I don't have a solid solution for how to actually call this callback, but it's causing me no end of grief. If you'd like, I can send you a testcase based on exrm-test which demonstrates the hanging behaviour.
