### PR TITLE
Don't depend on the indirect base64url dependency, use Base instead

### DIFF
--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -49,7 +49,7 @@ defmodule Joken.Signer do
     end
 
     %Signer{jws: %{"alg" => "none"}, jwk: %{"kty" => "oct",
-                                            "k" => :base64url.encode(secret)}}
+                                            "k" => Base.url_encode64(secret, padding: false)}}
   end
 
   @doc "Convenience for generating an HS*** Joken.Signer"
@@ -57,7 +57,7 @@ defmodule Joken.Signer do
   def hs(alg, secret) when is_binary(secret)
     and alg in ["HS256", "HS384", "HS512"] do
     %Signer{jws: %{"alg" => alg},
-            jwk: %{"kty" => "oct", "k" => :base64url.encode(secret)}}
+            jwk: %{"kty" => "oct", "k" => Base.url_encode64(secret, padding: false)}}
   end
 
   @doc "Convenience for generating an EdDSA Joken.Signer"
@@ -117,7 +117,7 @@ defmodule Joken.Signer do
   end
   def sign(token, %Signer{jws: jws, jwk: secret}) when is_binary(secret) do
     jwk = %{"kty" => "oct",
-            "k" => :base64url.encode(:erlang.iolist_to_binary(secret))}
+            "k" => Base.url_encode64(:erlang.iolist_to_binary(secret), padding: false)}
     sign(token, %Signer{jwk: jwk, jws: jws})
   end
   def sign(token, signer) do

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -37,7 +37,7 @@ defmodule Joken.Test do
     |> token
     |> sign(%Signer{
       jws: %{ "alg" => "HS256" },
-      jwk: %{ "kty" => "oct", "k" => :base64url.encode(:erlang.iolist_to_binary("secret")) }
+      jwk: %{ "kty" => "oct", "k" => Base.url_encode64(:erlang.iolist_to_binary("secret")) }
     })
 
     assert(signed_token.token == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.xuEv8qrfXu424LZk8bVgr9MQJUIrp1rHcPyZw_KSsds")


### PR DESCRIPTION
`base64url` is fetched via `jose` but is not specified in `mix.exs` of Joken itself. On the other hand, Joken can simply use `Base`.