### PR TITLE
Bump minimum Elixir version to 1.2.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Joken.Mixfile do
   def project do
     [app: :joken,
      version: @version,
-     elixir: "~> 1.2 or ~> 1.3",
+     elixir: "~> 1.2.3 or ~> 1.3",
      description: description,
      package: package,
      deps: deps,


### PR DESCRIPTION
Joken currently fails on Elixir versions prior to 1.2.3 due to the absence of `&Base.url_encode/2`. These versions only contain `&Base.url_encode/1` which does not allow passing `[padding: false]` as is done [here](https://github.com/bryanjos/joken/blob/master/lib/joken/signer.ex#L51). See https://github.com/elixir-lang/elixir/tree/v1.2.3.