### PR TITLE
Fix compile-time warning about :random module

### DIFF
--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -280,7 +280,7 @@ defmodule Joken.Test do
 
     token = %{}
     |> token
-    |> with_claim_generator("my_claim", fn -> "Random: #{inspect :random.uniform}" end)
+    |> with_claim_generator("my_claim", fn -> "Random: #{inspect :rand.uniform}" end)
 
     claims1 = token
     |> sign(hs256("secret"))


### PR DESCRIPTION
Right now, building the project throws such warning:

```
warning: random:uniform/0: the 'random' module is deprecated; use the 'rand' module instead
  test/joken_test.exs:283
```

This PR fixes it.

Also, one more warning is there while running unit tests: `on_verifying is deprecated for the Joken plug and will be removed in a future version.`. But looks like that's a feature. :)