### PR TITLE
Correct Joken.Token.t typespec

### DIFF
--- a/lib/joken/token.ex
+++ b/lib/joken/token.ex
@@ -19,10 +19,10 @@ defmodule Joken.Token do
     claims: claims,
     claims_generation: claim_function_map,
     validations: claim_function_map,
-    error: error,
+    error: error | nil,
     errors: errors,
-    token: token,
-    signer: signer
+    token: token | nil,
+    signer: signer | nil
   }
 
   defstruct [json_module: nil,
@@ -31,7 +31,7 @@ defmodule Joken.Token do
              claims_generation: %{},
              validations: %{},
              error: nil,
-             errors: nil,
+             errors: [],
              token: nil,
              signer: nil]
 


### PR DESCRIPTION
Several fields in the `Joken.Token` can actually be nil, but the typespec says they will always hold a different value. This causes Dialyzer warnings:

```elixir
defmodule Test do
  def test do
    Joken.token(%[])
  end
end
# => Dialyzer: Function test/0 has no local return
```