### PR TITLE
use parentheses to remove ambiguity

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -38,9 +38,9 @@ defmodule Joken do
     |> with_exp
     |> with_iat
     |> with_nbf
-    |> with_validation("exp", &(&1 > current_time))
-    |> with_validation("iat", &(&1 <= current_time))
-    |> with_validation("nbf", &(&1 < current_time))
+    |> with_validation("exp", &(&1 > current_time()))
+    |> with_validation("iat", &(&1 <= current_time()))
+    |> with_validation("nbf", &(&1 < current_time()))
   end
 
   @doc """
@@ -81,7 +81,7 @@ defmodule Joken do
   @spec with_exp(Token.t) :: Token.t
   def with_exp(token_struct = %Token{}) do
     token_struct
-    |> with_claim_generator("exp", fn -> current_time + (2 * 60 * 60) end)
+    |> with_claim_generator("exp", fn -> current_time() + (2 * 60 * 60) end)
   end
 
   @doc """
@@ -114,7 +114,7 @@ defmodule Joken do
   @spec with_nbf(Token.t) :: Token.t
   def with_nbf(token_struct = %Token{}) do
     token_struct
-    |> with_claim_generator("nbf", fn -> current_time - 1 end)
+    |> with_claim_generator("nbf", fn -> current_time() - 1 end)
   end
 
   @doc """

--- a/lib/joken/plug.ex
+++ b/lib/joken/plug.ex
@@ -126,13 +126,13 @@ if Code.ensure_loaded?(Plug.Conn) do
       case Keyword.take(options, [:verify, :on_verifying]) do
         [verify: verify] -> verify
         [verify: verify, on_verifying: _] ->
-          warn_on_verifying
+          warn_on_verifying()
           verify
         [on_verifying: verify] ->
-          warn_on_verifying
+          warn_on_verifying()
           verify
         [] ->
-          warn_supply_verify_function
+          warn_supply_verify_function()
           nil
       end
     end
@@ -148,7 +148,7 @@ if Code.ensure_loaded?(Plug.Conn) do
     defp set_joken_verify(conn, verify) do
       case conn.private do
         %{joken_on_verifying: deprecated_verify} ->
-          warn_on_verifying
+          warn_on_verifying()
           put_private(conn, :joken_verify, deprecated_verify)
         _ ->
           put_private(conn, :joken_verify, verify)

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -39,7 +39,7 @@ defmodule Joken.Signer do
   """
   @spec none(binary) :: Signer.t
   def none(secret) do
-    unless none_algorithm_allowed? do
+    unless none_algorithm_allowed?() do
       raise Joken.AlgorithmError, message: """
         'none' algorithm is not allowed.
         In order to use the 'none algorithm', the 'allow_none_algorithm' key on


### PR DESCRIPTION
I found some more warnings when compiling the dependency with elixir 1.4 :)