### PR TITLE
Change :iss claim key to "iss" in Joken.with_iss

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -126,11 +126,11 @@ defmodule Joken do
   end
 
   @doc """
-  Adds `:iss` claim with a given value.
+  Adds `"iss"` claim with a given value.
   """
   @spec with_iss(Token.t, any) :: Token.t
   def with_iss(token_struct = %Token{claims: claims}, issuer) do
-    %{token_struct | claims: Map.put(claims, :iss, issuer)}
+    %{token_struct | claims: Map.put(claims, "iss", issuer)}
   end
 
   @doc """


### PR DESCRIPTION
I got a dialyzer warning on this in my project, which is solved by changing the claim key to a String just like for the other claims.