### PR TITLE
Adds `token` option to `Joken.Plug`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ This plug accepts the following options in its initialization:
 return a tuple containing the conn and a binary representing the 401 response. If it's a map,
 it's turned into json, otherwise, it is returned as is.
 
+- `token` (option): a function used to return the token to verify.  By
+  default, the [Bearer authentication scheme in the
+Authorization header](https://tools.ietf.org/html/rfc6750) is used, but
+if your token happens to be stored somewhere else, you can set `token`
+to a function that will return the token to use instead.
+
 When using this with per route options you must pass a private map of options
 to the route. The keys that Joken will look for in that map are:
 


### PR DESCRIPTION
Hi -

I've been using Joken for communicating with Auth0.  Auth0 gives me an application token which I have to exchange for a "real" JWT via an API call.  This exchange occurs server-to-server, and the JWT is never put in the `Authorization` header as the spec says it should be; instead, I store it in session like Guardian et al would for a non-JWT authentication token, and I wanted to use Joken's existing Plug to protect resources in my Phoenix app.

This PR enables this by adding a `token` option to the plug, which makes where the actual token comes from configurable.  It keeps the existing default of getting it from the `Authorization` header if nothing is specified, so existing code should continue to work as expected.

I'm curious as to your feedback on if you think this is a valid approach or I'm just barking up the wrong tree.