### PR TITLE
Catch every invalid signature

### DIFF
--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -129,8 +129,7 @@ defmodule Joken.Signer do
     with {true, %JWT{fields: claims}, _} <- JWT.verify_strict(jwk, [alg], token) do
       {:ok, claims}
     else
-      {false, _, _} ->
-        {:error, :signature_error}
+      _ -> {:error, :signature_error}
     end
   end
 


### PR DESCRIPTION
Malformed or incorrect JWT's are not catched. It's helpful to always return a `signature_error`.