### PR TITLE
Fix aud setting on default_claims generated claims

### DIFF
--- a/lib/joken/config.ex
+++ b/lib/joken/config.ex
@@ -235,24 +235,25 @@ defmodule Joken.Config do
   - skip: do not include claims in this list. Ex: ["iss"]
   - default_exp: changes the default expiration of the token. Default is 2 hours
   - iss: changes the issuer claim. Default is "Joken" 
-  - aud: changes the audience claim
+  - aud: changes the audience claim. Default is "Joken"
   """
   @spec default_claims(Keyword.t()) :: Joken.token_config()
   def default_claims(options \\ []) do
     skip = options[:skip] || []
     default_exp = options[:default_exp] || 2 * 60 * 60
     default_iss = options[:iss] || "Joken"
+    default_aud = options[:aud] || "Joken"
     generate_jti = options[:generate_jti] || (&Joken.generate_jti/0)
 
-    unless is_integer(default_exp) and is_binary(default_iss) and is_function(generate_jti) and
-             is_list(skip) do
+    unless is_integer(default_exp) and is_binary(default_iss) and is_binary(default_aud) and
+             is_function(generate_jti) and is_list(skip) do
       raise Joken.Error, :invalid_default_claims
     end
 
-    generate_config(skip, default_exp, default_iss, generate_jti)
+    generate_config(skip, default_exp, default_iss, default_aud, generate_jti)
   end
 
-  defp generate_config(skip, default_exp, default_iss, generate_jti) do
+  defp generate_config(skip, default_exp, default_iss, default_aud, generate_jti) do
     gen_exp_func = fn -> current_time() + default_exp end
 
     Enum.reduce(@default_generated_claims, %{}, fn claim, acc ->
@@ -273,7 +274,7 @@ defmodule Joken.Config do
             add_claim(acc, "iss", fn -> default_iss end, &(&1 == default_iss))
 
           :aud ->
-            add_claim(acc, "aud", fn -> default_iss end, &(&1 == default_iss))
+            add_claim(acc, "aud", fn -> default_aud end, &(&1 == default_aud))
 
           :jti ->
             add_claim(acc, "jti", generate_jti)

--- a/test/joken_config_test.exs
+++ b/test/joken_config_test.exs
@@ -16,6 +16,13 @@ defmodule Joken.Config.Test do
       end
     end
 
+    property "any given audience will be validated" do
+      check all audience <- binary() do
+        aud_claim = Config.default_claims(aud: audience)["aud"]
+        assert aud_claim.validate.(audience, %{}, %{})
+      end
+    end
+
     test "generates exp, iss, iat, nbf claims" do
       assert Config.default_claims() |> Map.keys() == ["aud", "exp", "iat", "iss", "jti", "nbf"]
     end
@@ -42,8 +49,16 @@ defmodule Joken.Config.Test do
       assert Config.default_claims(skip: [:aud, :exp, :iat, :iss, :jti, :nbf]) == %{}
     end
 
-    test "can set a different issuer" do
-      assert Config.default_claims(iss: "Custom")["iss"].generate.() == "Custom"
+    test "defaults audience and issuer to Joken" do
+      claims = Config.default_claims()
+      assert claims["aud"].generate.() == "Joken"
+      assert claims["iss"].generate.() == "Joken"
+    end
+
+    test "can set a different audience and issuer" do
+      claims = Config.default_claims(aud: "aud", iss: "iss")
+      assert claims["aud"].generate.() == "aud"
+      assert claims["iss"].generate.() == "iss"
     end
 
     test "default exp validates properly" do


### PR DESCRIPTION
Fix `default_claims` function to set `aud` value correctly when `aud` option passed.