### PR TITLE
fix: fix issue with nil generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@ For changes on versions 1.x look on the v1.5 branch.
 
 * Backwards incompatible changes
 
-- There is no `Joken.Plug` module anymore. Depending on requests we can bring that back, but we believe it is better to have that on a different library;
+- There is no `Joken.Plug` module anymore. Depending on requests we can bring that back, but we believe it is better to be on a different library;
+- The API surface changed a lot but you can still use Joken with the same [token pattern as versions 1.x](http://trivelop.de/2018/05/14/flow-elixir-designing-apis/). Please see our migrating guide.

--- a/lib/joken/claim.ex
+++ b/lib/joken/claim.ex
@@ -17,8 +17,8 @@ defmodule Joken.Claim do
 
   @doc false
   def __generate_claim__({key, %__MODULE__{generate: gen_fun}}, acc)
-      when is_function(gen_fun) and is_binary(key) and is_map(acc) do
-    case Map.has_key?(acc, key) do
+      when is_binary(key) and is_map(acc) do
+    case Map.has_key?(acc, key) or not is_function(gen_fun, 0) do
       true ->
         acc
 
@@ -26,4 +26,6 @@ defmodule Joken.Claim do
         Map.put(acc, key, gen_fun.())
     end
   end
+
+  def __generate_claim__(_, acc), do: acc
 end

--- a/test/joken_claim_test.exs
+++ b/test/joken_claim_test.exs
@@ -1,0 +1,20 @@
+defmodule Joken.ClaimTest do
+  use ExUnit.Case, async: true
+
+  alias Joken.Claim
+
+  test "can generate values" do
+    claim = %Claim{generate: fn -> "New Value" end}
+    assert Claim.__generate_claim__({"val", claim}, %{}) == %{"val" => "New Value"}
+  end
+
+  test "when generate function is nil skips generation" do
+    claim = %Claim{generate: nil}
+    assert Claim.__generate_claim__({"val", claim}, %{}) == %{}
+  end
+
+  test "when generate function has arity different than 0 skips generation" do
+    claim = %Claim{generate: fn _wth -> "nope wont do" end}
+    assert Claim.__generate_claim__({"val", claim}, %{}) == %{}
+  end
+end


### PR DESCRIPTION
When using JWKS you will probably not use generators because you will
only be verifying instead of generating tokens. This use case is
pictured in our common use cases guide but wasn't actually working
unfortunately. This fixes that.