### PR TITLE
Pass errors to caller for peek_* functions

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -122,12 +122,14 @@ defmodule Joken do
   will be used. Even though there is a use case for this, be extra careful to handle data without 
   validation.
   """
-  @spec peek_header(bearer_token) :: claims
+  @spec peek_header(bearer_token) :: {:ok, claims} | {:error, error_reason}
   def peek_header(token) when is_binary(token) do
-    with {:ok, %{"protected" => header}} = expand(token) do
+    with {:ok, %{"protected" => header}} <- expand(token) do
       header
       |> Base.url_decode64!(padding: false)
-      |> Jason.decode!()
+      |> Jason.decode()
+    else
+      error -> error
     end
   end
 
@@ -139,12 +141,14 @@ defmodule Joken do
   will be used. Even though there is a use case for this, be extra careful to handle data without 
   validation.
   """
-  @spec peek_claims(bearer_token) :: claims
+  @spec peek_claims(bearer_token) :: {:ok, claims} | {:error, error_reason}
   def peek_claims(token) when is_binary(token) do
-    with {:ok, %{"payload" => claims}} = expand(token) do
+    with {:ok, %{"payload" => claims}} <- expand(token) do
       claims
       |> Base.url_decode64!(padding: false)
-      |> Jason.decode!()
+      |> Jason.decode()
+    else
+      error -> error
     end
   end
 

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -124,10 +124,10 @@ defmodule Joken do
   """
   @spec peek_header(bearer_token) :: {:ok, claims} | {:error, error_reason}
   def peek_header(token) when is_binary(token) do
-    with {:ok, %{"protected" => header}} <- expand(token) do
-      header
-      |> Base.url_decode64!(padding: false)
-      |> Jason.decode()
+    with {:ok, %{"protected" => protected}} <- expand(token),
+         {:ok, decoded_str} <- Base.url_decode64(protected, padding: false),
+         {:ok, header} <- Jason.decode(decoded_str) do
+      {:ok, header}
     else
       error -> error
     end
@@ -143,10 +143,10 @@ defmodule Joken do
   """
   @spec peek_claims(bearer_token) :: {:ok, claims} | {:error, error_reason}
   def peek_claims(token) when is_binary(token) do
-    with {:ok, %{"payload" => claims}} <- expand(token) do
-      claims
-      |> Base.url_decode64!(padding: false)
-      |> Jason.decode()
+    with {:ok, %{"payload" => payload}} <- expand(token),
+         {:ok, decoded_str} <- Base.url_decode64(payload, padding: false),
+         {:ok, claims} <- Jason.decode(decoded_str) do
+      {:ok, claims}
     else
       error -> error
     end

--- a/test/joken_signer_test.exs
+++ b/test/joken_signer_test.exs
@@ -89,11 +89,11 @@ defmodule Joken.Signer.Test do
     signer = Signer.create("HS256", "secret", %{"kid" => key_id})
 
     {:ok, token, _claims} = Joken.encode_and_sign(%{}, signer)
-    assert %{"kid" => ^key_id, "alg" => "HS256"} = Joken.peek_header(token)
+    assert {:ok, %{"kid" => ^key_id, "alg" => "HS256"}} = Joken.peek_header(token)
   end
 
   test "can parse with key_id" do
     {:ok, token, _claims} = Joken.encode_and_sign(%{}, Signer.parse_config(:with_key_id))
-    assert %{"kid" => "my_key_id", "alg" => "HS256"} = Joken.peek_header(token)
+    assert {:ok, %{"kid" => "my_key_id", "alg" => "HS256"}} = Joken.peek_header(token)
   end
 end

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -18,13 +18,23 @@ defmodule JokenTest do
   describe "token introspection" do
     test "can peek header" do
       jwt = EmptyToken.generate_and_sign!()
-      assert Joken.peek_header(jwt) == %{"typ" => "JWT", "alg" => "HS256"}
+      assert Joken.peek_header(jwt) == {:ok, %{"typ" => "JWT", "alg" => "HS256"}}
+    end
+
+    test "peek header passes error up with invalid token" do
+      jwt = "not a token"
+      assert Joken.peek_header(jwt) == {:error, :token_malformed}
     end
 
     test "can peek body" do
       custom_claims = %{"my" => "claim"}
       jwt = EmptyToken.generate_and_sign!(custom_claims)
-      assert Joken.peek_claims(jwt) == custom_claims
+      assert Joken.peek_claims(jwt) == {:ok, custom_claims}
+    end
+
+    test "peek body passes error up with invalid token" do
+      jwt = "not a token"
+      assert Joken.peek_claims(jwt) == {:error, :token_malformed}
     end
   end
 


### PR DESCRIPTION
Hello again,

This allows for errors from malformed tokens to be easily matched against when called. The previous method required handling a match error. This also changes the success route to returning an {:ok, _} tuple.

I figured changing the return type so that errors are passed up also warranted the change to use an `{:ok, _}` tuple instead. Let me know what you think!

Thanks!